### PR TITLE
Isolate the Settings defaults tests from .env (closes TODO T4)

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -94,7 +94,24 @@ one shape, not two. Pick deliberately; (b) is the smaller change.
 
 ---
 
-## T4 — `test_default_port_is_8000` reads the developer's real `.env`
+## ~~T4 — `test_default_port_is_8000` reads the developer's real `.env`~~
+
+**Closed 2026-07-12.** `TestSettingsDefaults` now takes a `default_settings` fixture that clears every
+`Settings` field's env var and passes `_env_file=None`, so the class asserts the code's declared
+defaults rather than the machine's configuration. `PORT=8010` in the local `.env` is intentional
+(it avoids a port clash) and is no longer the suite's problem.
+
+The leak was class-wide, not port-specific: `test_facets_dir_default` had already been patched by
+hand to pass `facets_dir=` because `conftest` exports `FACETS_DIR` — a workaround for this same
+cause, applied to one field. The fixture fixes it at the source. A companion test asserts the env
+var still *wins* when present, so the isolation can't hide a real regression.
+
+Full suite is green on a machine with a populated `.env`: **1026 passed, 0 failed.**
+
+---
+
+<details>
+<summary>Original report</summary>
 
 **Source:** PR #5 review (2026-07-11). **Pre-existing — predates the PR.**
 
@@ -112,3 +129,5 @@ developer-local state, which is exactly what a defaults test should not do.
 suppressed (e.g. `Settings(_env_file=None)`), so they assert real defaults rather
 than whatever the local `.env` happens to hold. Full suite should be green on a
 machine with a populated `.env`.
+
+</details>

--- a/software/tests/test_config.py
+++ b/software/tests/test_config.py
@@ -7,59 +7,74 @@ from pathlib import Path
 import pytest
 
 
+@pytest.fixture
+def default_settings(monkeypatch):
+    """`Settings` as the *code* declares it — isolated from `.env` and the
+    process environment.
+
+    `Settings` resolves env vars first, `.env` second, and field defaults last.
+    So a test that asserts a documented default while letting those two layers
+    through isn't testing the default at all — it's testing whatever the machine
+    happens to be configured with. This repo's `.env` sets `PORT=8010` to dodge a
+    local port clash, and that alone made `test_default_port_is_8000` fail on
+    every checkout for reasons that had nothing to do with the code. `conftest`
+    exports `FACETS_DIR` and `DATA_DIR` for the same reason, which is why
+    `test_facets_dir_default` used to pass `facets_dir=` by hand — a workaround
+    for this exact leak, applied to one field instead of the cause.
+
+    Clearing every field's env var and disabling `.env` fixes it at the source,
+    for the whole class.
+    """
+    from app.config import Settings
+
+    for field in Settings.model_fields:
+        monkeypatch.delenv(field.upper(), raising=False)
+        monkeypatch.delenv(field, raising=False)
+
+    return Settings(_env_file=None, secret_key="test-key")
+
+
 class TestSettingsDefaults:
     """Verify every documented default value."""
 
-    def test_default_host_is_localhost(self):
-        from app.config import Settings
-        s = Settings(secret_key="test-key")
-        assert s.host == "127.0.0.1"
+    def test_default_host_is_localhost(self, default_settings):
+        assert default_settings.host == "127.0.0.1"
 
-    def test_default_port_is_8000(self):
-        from app.config import Settings
-        s = Settings(secret_key="test-key")
-        assert s.port == 8000
+    def test_default_port_is_8000(self, default_settings):
+        assert default_settings.port == 8000
 
-    def test_debug_is_false_by_default(self):
-        from app.config import Settings
-        s = Settings(secret_key="test-key")
-        assert s.debug is False
+    def test_debug_is_false_by_default(self, default_settings):
+        assert default_settings.debug is False
 
-    def test_external_url_is_empty_by_default(self):
-        from app.config import Settings
-        s = Settings(secret_key="test-key")
-        assert s.external_url == ""
+    def test_external_url_is_empty_by_default(self, default_settings):
+        assert default_settings.external_url == ""
 
-    def test_algorithm_is_hs256(self):
-        from app.config import Settings
-        s = Settings(secret_key="test-key")
-        assert s.algorithm == "HS256"
+    def test_algorithm_is_hs256(self, default_settings):
+        assert default_settings.algorithm == "HS256"
 
-    def test_mm_token_expire_hours_default(self):
-        from app.config import Settings
-        s = Settings(secret_key="test-key")
-        assert s.mm_token_expire_hours == 8
+    def test_mm_token_expire_hours_default(self, default_settings):
+        assert default_settings.mm_token_expire_hours == 8
 
-    def test_invite_token_expire_hours_default(self):
-        from app.config import Settings
-        s = Settings(secret_key="test-key")
-        assert s.invite_token_expire_hours == 24
+    def test_invite_token_expire_hours_default(self, default_settings):
+        assert default_settings.invite_token_expire_hours == 24
 
-    def test_facets_dir_default(self):
-        from app.config import Settings
-        # Pass facets_dir explicitly to avoid FACETS_DIR env var set by conftest
-        s = Settings(secret_key="test-key", facets_dir=Path("facets"))
-        assert s.facets_dir == Path("facets")
+    def test_facets_dir_default(self, default_settings):
+        assert default_settings.facets_dir == Path("facets")
 
-    def test_roll_rate_limit_default(self):
-        from app.config import Settings
-        s = Settings(secret_key="test-key")
-        assert s.roll_rate_limit == "10/minute"
+    def test_roll_rate_limit_default(self, default_settings):
+        assert default_settings.roll_rate_limit == "10/minute"
 
-    def test_auth_rate_limit_default(self):
+    def test_auth_rate_limit_default(self, default_settings):
+        assert default_settings.auth_rate_limit == "5/minute"
+
+    def test_env_var_overrides_the_default(self, monkeypatch):
+        """The isolation above must not hide a real regression: with the env var
+        present, it still wins over the default. This is what makes PORT=8010
+        work in the first place."""
         from app.config import Settings
-        s = Settings(secret_key="test-key")
-        assert s.auth_rate_limit == "5/minute"
+
+        monkeypatch.setenv("PORT", "8010")
+        assert Settings(_env_file=None, secret_key="test-key").port == 8010
 
 
 class TestSettingsEnvOverride:


### PR DESCRIPTION
The last failing test in the suite. `PORT=8010` in the local `.env` is **deliberate** — it avoids a port clash — so the fix is to stop the test caring, not to change the port.

## The bug

`Settings` resolves **env vars first, `.env` second, field defaults last**. `TestSettingsDefaults` constructed `Settings(secret_key="test-key")` and let all three layers through — so it wasn't asserting the code's defaults, it was asserting whatever the developer's machine happened to be configured with. On any checkout with `PORT` set: `assert 8010 == 8000`.

**The leak was class-wide, not port-specific.** `test_facets_dir_default` already carried a hand-rolled workaround:

```python
# Pass facets_dir explicitly to avoid FACETS_DIR env var set by conftest
s = Settings(secret_key="test-key", facets_dir=Path("facets"))
```

Same cause, patched one field at a time. `port` was simply the field nobody had gotten to yet.

## The fix

A `default_settings` fixture clears every `Settings` field's env var and passes `_env_file=None`, so the class asserts declared defaults at the source. The `facets_dir=` hand-patch is deleted — it's now redundant.

## Guarding against a neutered test

Isolation that silently disables the assertions would be worse than the failure it replaced, so:

- **A companion test** asserts the env var still *wins* when present (`PORT=8010` → `8010`). That's the behaviour that makes your `.env` work, and it's now pinned rather than assumed.
- **Mutation-verified.** Changing the code default to `9000` still fails the test (`assert 9000 == 8000`), confirming it catches a real regression.

## Test plan

- [x] `pytest -q` — **1026 passed, 0 failed.** First fully-green suite; previously 1024 passed / 1 failed.
- [x] Green on a machine with a populated `.env` (this one, `PORT=8010`).
- [x] Mutation test: code default `8000` → `9000` fails as it should.

TODO T4 struck and closed with the resolution recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)