### PR TITLE
Oraga Night: a masquerade that goes wrong on schedule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,11 @@ software/data/agentic_playtest/
 *.swo
 *.code-workspace
 
+# Author's private worldbuilding source material — kept locally, never distributed.
+# This repository is public; source notes compiled from the private setting corpus
+# are working scaffolding, not reader-facing content.
+references/oraga_night/
+
 # Local agent-assistant workspace (unrelated to this project)
 .openclaw/
 /AGENTS.md

--- a/adventures/oraga_night/01_Overture.md
+++ b/adventures/oraga_night/01_Overture.md
@@ -1,0 +1,168 @@
+# I. Overture — How to Run Oraga Night
+
+## What This Adventure Is
+
+Oraga Night is a masquerade for **three to five characters**, freshly made or taken from the pregenerations in Chapter III. It expects no Facet levels and no Techniques — this is a first-session module, and every problem in it can be solved by people who own nothing but a Background and a good idea. Characters end the night mechanically where they began; what they leave with is Sparks, obligations, three or four people who now know their names, and the only first-hand account of something the city will spend a generation lying about.
+
+**One session**, four to six hours, as written. **Three to four sessions** with the optional wings in Chapter VI.
+
+## What You Need
+
+The Facets of Origin core rules — 2d6 plus attribute plus skill against a difficulty, Sparks, Conditions, and the exchange structure for the two Movements that turn violent. No grid, no miniatures.
+
+Everything setting-specific is in this module. Chapter VIII covers the tribes of Val'loh, their gifts, and how magic behaves differently here; Chapter VII holds every named guest; the enemy `.fof` files hold every stat line you will need. You do not need any other Facet to run this.
+
+Print the handouts in Chapter IX before you sit down — the agenda cards and the invitation, at minimum, and the night-tracker for yourself.
+
+## The Story So Far
+
+**The house.** Raunu Boranis — genius, maniac, or both — vanished for a year, came back without explanation, married across tribal lines, and shut his palace for two more. Everyone of importance loathes him. Nearly all of them will come anyway.
+
+**The night.** On the last night of the Oraga harvest festival, the doors open. Two hundred masked guests, a host who does not appear, and three guests nobody invited.
+
+**The truth.** Chapter II gives it to you whole — who the Uninvited are, what they came for, what constrains them, and why none of it will ever be public. Read that chapter before you run anything.
+
+**The record.** History says Raunu Boranis died at his own ball, that his wife and newborn vanished, that no one was charged, and that no one ever learned the truth. That is the default outcome, and Chapter V explains how the night bends toward it through play rather than against it.
+
+## The Night in Seven Movements
+
+**Movement I — The Receiving Line.** The party arrives, is received by name, and discovers that nobody is being disarmed. *By the end: everyone is inside, and the honor guard is facing the wrong way.*
+
+**Movement II — The Empty Rooms.** The ball proper, and the longest Movement. Agendas move; the host does not appear. *By the end: his absence has stopped being funny.*
+
+**Movement III — The Summons.** Raunu begins receiving guests one at a time, and at least one of them should be a player character. *By the end: somebody at the table has met him.*
+
+**Movement IV — The Toast.** The host finally appears in public, says something nobody expected, and leaves. *By the end: the room has been told something it does not know what to do with.*
+
+**Movement V — The Hour of Spirits.** The last hour before midnight. Every thread the party has pulled comes taut at once. *By the end: anyone who assembled the pattern has one chance to act on it.*
+
+**Movement VI — The Unmasking.** Midnight. The masks come off, and three guests keep theirs on. *By the end: the host is dead, and the party is choosing who to save.*
+
+**Movement VII — The Longest Night.** Fire, dark, and the walk out. *By the end: the party is standing outside with whatever and whoever they carried out.*
+
+## Getting the Party In
+
+Every character arrives holding an invitation story (Chapter III) and an agenda (Chapter III). Those are the hooks, and they all converge on the same first scene: **begin every character at the Gatehouse Court, B1, Movement I.** Nobody starts inside; nobody starts separately.
+
+**The invited.** Prominent enough to be sent for by name, or serving someone who was.
+**The entourage.** Somebody invited needed a companion, a bodyguard, a translator, or a witness.
+**The wrong name.** A discarded invitation with somebody else's name on it, and a mask custom that makes that survivable.
+**The hired.** Festival staff, taken on quietly by a house whose own staff was cut to the bone — a servant's freedom of the halls, and a servant's invisibility.
+**The errand.** A faction needed hands that could not be traced back to it, and paid half up front.
+
+Run session zero as a table: each player picks an arrival and an agenda, and the party works out how much of that they are telling each other. They do not have to tell each other anything.
+
+## How This Module Is Written
+
+**Keyed rooms** are `**B1. The Room Name.**` — a code, a name, then what is there. The codes are the same in the text, the night-tracker, and every cross-reference; they ascend in reading order, public rooms first, then the private palace.
+
+***Italic blocks*** are read-aloud. Every one has a trigger line above it in plain text saying when to read it. They describe only what the characters can perceive, they never say what anyone feels or does, and they never name a thing the players have not identified for themselves. Cut anything in one that your table's approach has already contradicted.
+
+**Boxed sidebars** come in three kinds, and the label says which: **Sidebar —** for a piece of the world that would otherwise derail the paragraph it sits in; **⟨If History Breaks⟩** for the places where the players can genuinely overturn the recorded outcome, each one telling you what changes and how to run forward; and **MM Note** for technique.
+
+**Enemies** are named by their stat file — `enemies/tavva.fof` — and every one of them carries its conduct and its morale line in the file, not just its numbers. No fight in this module is to the death by default.
+
+**Where the module says *the module does not say*,** that is load-bearing. See *What the MM Knows*, below in this chapter.
+
+## What the Night Pays
+
+Print these. The module's own rule is that clever and peaceful play is paid on the page rather than left to your generosity in the moment — you will be tired by Movement VI, and a reward you have to remember to invent is a reward that does not happen.
+
+**Completing an agenda:** one Spark, on the spot, as Chapter III says.
+
+**Reading an omen before it is explained:** one Spark, to the character who says the thing out loud at the table. There are five omens and they are each worth exactly one; a party that catches all five has earned the right to act before midnight, and the Sparks are how they afford to.
+
+**Getting into a closed room without a fight:** one Spark. Corval's gratitude, Anha's service passages, an audience-earned pass, a festival hire's livery — all of them count, and none of them is worth less than kicking the door.
+
+**Ending a fight without finishing it:** one Spark each to everyone involved. Talking the honor guard down, paying the toll, letting the thieves leave with something they can afford to lose. The steel in this module is opt-in on purpose (see *Optional Steel*, Chapter IX); declining it is a choice the module pays for, not a scene skipped.
+
+**Carrying somebody out:** one Spark per person saved in Movement VII, to whoever carried them. Not per attempt — per person standing outside at the end.
+
+**A player character telling the truth about the night afterward, at cost:** one Spark. The inquest wants a story that fits. Anyone who declines to give it one has paid for something, and this is the module paying back.
+
+None of these replaces the ordinary earning rules. A Graceful Fail is still a Graceful Fail, and the best moment of the evening still gets a Spark whether or not it appears on this list.
+
+## The Shape of the Night
+
+Oraga Night is a masquerade with an event clock. The evening is divided into seven
+**Movements**, like a dance program. Each Movement has scheduled events that happen
+regardless of the players, open time for the characters to chase their agendas, and one
+**omen** — a detail that is quietly wrong. The Movements advance when the table's energy
+says so, not when a timer does; the night-tracker in Chapter IX gives you the whole
+program on one page.
+
+For most of the evening this is a social adventure. The player characters maneuver,
+charm, eavesdrop, trespass, and trade favors under two hundred masks. Then, at midnight,
+the masks come off — and three guests keep theirs on. The last two Movements are a
+different game: darkness, fire, terror, and choices about who to save and what to carry
+out of the wreckage.
+
+Tell your players honestly what they are signing up for: *a glittering party that goes
+terribly wrong.* Do not tell them how.
+
+## Tone: Glamour Over a Blade
+
+Play the first five Movements warm. The wine is good, the music is better, the gossip is
+excellent, and the political fencing is genuinely fun. Rekuzan knows how to throw a
+festival, and House Boranis, silent for two years, has thrown open its doors with
+strange, sincere generosity. Let the players enjoy the party. Their enjoyment is the
+ballroom floor you will drop out from under them.
+
+The wrongness arrives on schedule, one omen per Movement, always deniable. A merchant
+who keeps glancing at doors. A falconry mews screaming at nothing. A charming guest
+whose turns of phrase are a century out of fashion. Never underline an omen. Say it
+once, plainly, and move on. Players who
+notice will assemble the pattern themselves, and players who assemble the pattern earn
+the best reward this night has: the chance to act *before* midnight.
+
+
+When the Unmasking comes, change your voice. Shorter sentences. Fewer adjectives. The
+party is over.
+
+One register note: this is a night of wonder and courage as much as fear. People are
+brave in it. Guests shield strangers, servants pull nobles out of fire, and the player
+characters get every chance to be the best people in the room. End the night on what
+they saved, not on what they lost.
+
+## Canon and Your Table
+
+Oraga Night dramatizes a real event in the history of Svara. History records it this
+way: **Raunu Boranis died at his own ball. His wife and newborn child vanished that
+night. No one was ever charged, and no one ever learned the truth.**
+
+The module presents that outcome as the default, and it is built so the default lands
+through play, not against it — Chapter V explains how the night bends toward history
+without ever taking the dice out of the players' hands.
+
+But it is your table. Sidebars marked **⟨If History Breaks⟩** appear wherever the
+players might genuinely derail the recorded outcome — saving Raunu, capturing one of
+the Uninvited, stopping the escape at the river gate — and each one tells you what
+changes and how to run forward. A table that saves Raunu Boranis has not played the
+module wrong. It has written its own Val'loh, and Chapter V will help you keep it
+standing.
+
+## What the MM Knows (And What the MM Doesn't)
+
+Chapter II gives you the operational truth of the night: who the Uninvited are in
+practice, what they came for, what constrains them, who the pale factor is working
+against them, and why none of it will ever be public. That truth is complete enough to
+run every scene and answer every reasonable player action.
+
+It is not the whole truth. Where the module says *the module does not say*, that is a
+load-bearing sentence, not a gap. Raunu's missing year, the full nature of the
+Uninvited's distant master, what the child will one day become — these are mysteries the
+module keeps on purpose. Resist the urge to invent answers at the table; the honest
+version of this night is the one where even the survivors die not knowing.
+
+## Safety and the Table
+
+This adventure contains violence erupting inside a celebration, the death of a host in
+front of his guests, and mortal danger near (never to, and never on-screen) a woman in
+late pregnancy and a newborn. Say so during session zero. Agree on lines and veils
+before play; the pregnancy is central to the plot and cannot be cut, but every moment of
+harm can be handled by cutaway. The module's own camera never lingers: when the worst
+happens, it happens at the edge of the frame, glimpsed through a crowd.
+
+One MM tip above all others: **know the cast, not the script.** The night survives any
+player plan if you know what each named guest wants, fears, and will do when the lights
+go out. That is Chapter VII, and it is the chapter to reread before you sit down.

--- a/adventures/oraga_night/02_The_World_and_the_Night.md
+++ b/adventures/oraga_night/02_The_World_and_the_Night.md
@@ -1,0 +1,247 @@
+# II. The World and the Night
+
+*Everything in this chapter up to "The Truth of the Night" is public knowledge or
+common rumor — safe to share with players as their characters would know it. The
+final section is yours alone.*
+
+## Val'loh, 3164 PG
+
+The continent of Val'loh is in perpetual conflict, and has been for as long as its
+stories reach back. To the west, the mage tribes skirmish with Mazaa in the sacred
+mountains, where the power of the gods draws nearer to the land than anywhere else and
+the ungifted Mazaaians dig for god-touched stones — desecration, the tribes say,
+disturbing things that should not be disturbed. To the east, the Blackwatch keeps its
+vigil over the mists that roll in from the sea like tides — the mists the Church calls
+a warning against pride and blasphemy, left over from sins old enough that no one can
+name them anymore.
+
+These two threats unite the tribes under the gods and their Church. Nothing else does.
+The tribes war over territory as their grandparents did, and the Church blesses it:
+the strong are chosen by Fraden, and so the strong deserve what they take.
+
+This year, something is different, and almost nobody has noticed. **The eastern mists
+have receded to record lows.** The coast is clearer than living memory. The Blackwatch,
+who prefer predictable, are quietly unnerved — an unexplained low tide is not a gift,
+it is a held breath. News of it travels inland as a curiosity, a line of gossip for
+people who like eerie stories. Keep it in the players' peripheral vision. It matters.
+
+## Rekuzan
+
+The first city of Val'loh, and still by far its largest and most stable — the crown
+jewel of the Orthaen, the dominant tribe of the central farmlands. In the deep past
+Rekuzan was nine walled districts: one for each of the eight sects of the Orthaen, and
+a ninth at the center for trade. The city has long since swallowed the gaps between
+them with wood-and-stone homes, taverns, and industry, but the old district walls still
+stand — walls of **pink crystal**, grown over generations by the Orthaen gift, luminous
+at dusk. The sect palaces are crystal too. Everything else in the city is dull by
+comparison, and knows it.
+
+The eight sects of the Orthaen are, in the order their banners hang in the Chiefs'
+Concourse: **Boranis, Draunel, Morrain, Vaskarin, Solvane, Kethaun, Tessarin, and
+Ilvane.** House Boranis holds the chieftaincy, and has for generations.
+
+One fact about this world that players raised on other settings must hear early:
+**there are no books.** By god-ordained law, ancient beyond memory, the written word
+belongs to the Church and to no one else — the Church writes what its necessity
+requires, and everyone else remembers. Val'loh's knowledge lives in memory, in
+apprenticeship, in the Scora's sanctioned cloth-strip rite, and in crystal.
+Histories are recited, accounts are kept in tally-cords and in stewards' heads,
+testaments are sworn aloud before witnesses. The rare exceptions are jealously
+narrow: a great house's formal invitation, a few lines under a chief's own hand,
+is among the few writings the Church suffers outside its walls, which is part of
+why a genuine invitation is worth so much to the wrong person.
+
+## The Oraga Nights
+
+The harvest festival — three nights at the turn of the season, the emotional peak of
+the Val'loh year. Oraga celebrates the yield, steels the community for the harder
+season ahead, and honors those lost along the way. The living feast so the year's dead
+can hear it.
+
+On the final night, Rekuzan wears masks. By old custom, the masks are **spirit-faces**:
+the dead of the year, the spirits of the harvest, the luck and grief of the season made
+wearable. To wear a mask on the last night of Oraga is to lend your body to something
+that no longer has one — a courtesy to the departed, and a license for the living, since
+nothing said or done behind a spirit's face is entirely *yours*. At midnight the bells
+ring the **Unmasking**: the masks come off, the spirits are thanked and sent home, and
+the living toast the year to come with their own faces.
+
+It is a beloved, boisterous, slightly dangerous custom. Affairs begin behind masks.
+Debts are forgiven and grudges declared. And every Oraga, somebody uses the custom for
+business that cannot stand daylight — which is why the great houses post extra guards,
+and why nobody is ever quite comfortable at the Unmasking bell, even before this year.
+
+## House Boranis: The Ladder of Strange Years
+
+What every guest at the ball knows, in order:
+
+1. **3160 — The Disappearance.** Raunu Boranis, chief of the Orthaen — called a genius,
+   a maniac, or both since childhood — vanishes without explanation. His younger brother
+   **Vorlain** kills two cousins in a brief, efficient scuffle and secures the Boranis
+   sect, preserving the family's hold on the chieftaincy.
+2. **3161 — The Return.** Raunu walks back into his hall one day and takes his seat,
+   receiving ministers as if nothing had happened. Vorlain — a conniving man who has
+   feared exactly one person in his life — yields without a word. Where Raunu went, and
+   why, he has never said. *(See the rumor table in Chapter IX. The module does not
+   answer this question, and neither should you.)*
+3. **3162 — The Pact and the Marriage.** Raunu announces a pact with the Thenya — a
+   diminished tribe under heavy Orthaen border pressure — trading protection for a
+   marriage between himself and **Veier Nolonaire**, cousin of the Thenyan chief. The
+   wedding at the Boranis chapel is small, formal, and by every account bloodless in
+   both senses. Cross-tribe marriages are nearly unheard of. Nobody knows what to make
+   of it.
+4. **3162–3164 — The Silence.** The palace staff is cut four-fold. A lively seat of
+   power goes eerily quiet. Veier is last seen through a palace window three months
+   after the wedding. Rumor fills the vacuum: they are prisoners, they are dead, the
+   chief is mad at last, the Thenya bride poisoned him, he poisoned her.
+5. **3164, harvest — The Invitations.** On the eve of the Oraga Nights, House Boranis
+   sends out invitations to a masquerade ball in the Crystal Court, for the final night
+   of the festival, under Raunu's own hand. The city loses its mind.
+
+## Who Hates Raunu Boranis (Everyone)
+
+Raunu is, by a wide margin, the best-loved Orthaen chief in generations — by commoners.
+His wage floors, worker protections, and tax policies consider the working man first
+and the nobility when convenient. Which is precisely why every guest of importance at
+his ball despises him:
+
+- **The Merchant's Circle** bleeds margin under his policies and would pay handsomely
+  to know what he plans next — or to arrange that he plans nothing ever again.
+- **The Church** finds him illegible. A chief it cannot predict is a chief it cannot
+  steer, and the Church steers everyone. His disappearance, return, and silence read
+  to the priesthood like a theological insult they cannot name.
+- **The seven other sects** understand the arithmetic: his popularity makes him
+  impossible to unseat, and even if they managed it, the commons would compare every
+  successor to him and revolt.
+- **His own house** sees a ceiling. No Boranis rises while Raunu holds the seat, and
+  Vorlain's single year of rule taught several cousins how quickly the seat can change.
+- **The Thenya** do not hate him — they need him, which is worse. Their pact holds
+  only while he lives, and their kinswoman disappeared into his silent palace two
+  years ago. They are coming to the ball to see her with their own eyes.
+
+Most invitations will be accepted out of burning curiosity. Some will be burned. A few
+will be discarded — and a discarded invitation to the Boranis ball is worth a great
+deal to the right wrong person, which is one of the ways player characters get in.
+
+---
+
+---
+
+# The Truth of the Night — MM ONLY
+
+*Operational truth: everything you need, nothing you don't.*
+
+## What Is Coming
+
+Three killers are coming to the ball. The module calls them **the Uninvited**; they
+will arrive masked as Oraga spirits, and they will be the three best-disguised guests
+in the palace, because the custom of the night was practically written for them.
+
+Treat them as what they are operationally: **bound servants of a power sealed away
+in the far east, beyond the mists** — and understand the thing that makes them work
+at the table: **they are people.** Not revenants, not shades. Men and women, ancient
+and bound, who eat the food and praise the wine and dance beautifully in a style
+nobody living learned. What makes them monstrous is not what was taken from them but
+how much is left — grief, faith, exhaustion, courtesy — and every scene with one of
+them should be played as a scene with a person. Do that, and the horror takes care
+of itself. Their master cannot act. They
+can, barely, briefly: the receding mists are the outward sign of a door standing
+ajar, and the Uninvited have slipped through it on a leash. The leash is real. As the
+night wears on, something pulls them east, harder every hour. By the last bell of
+Oraga they *must* go, whatever is finished and whatever is not. This is why they do
+not simply slaughter the palace: they have one night, one task, and no time.
+
+Two more operational facts. They are fast in a way that has nothing to do with
+running — they slip through the world's shadow and arrive — and ordinary doors,
+walls, and barricades do not reliably hold them; only deep Boranis ward-crystal
+does. And whatever greater powers they once wielded are sealed away with their
+master: tonight they are speed, craft, and centuries of practice. That is
+terrible enough.
+
+**The task:** kill Raunu Boranis, kill Veier Nolonaire, and carry away the child she
+is about to deliver. The parents are the errand. **The child is the prize.** Something
+about this child should not be possible, and the sealed power in the east wants him —
+alive, controlled, and gone. What the child is, and why he matters, the module does
+not say. It is enough that two hidden powers already know.
+
+## Why the Ball
+
+Raunu Boranis threw this ball for one reason: **to announce, at the midnight
+Unmasking, that his wife is with child.** Two years of silence, ended on his own
+terms, in the one hour custom compels every host to stand before his guests. Pride,
+defiance, and (because he is who he is) control: the announcement, the audience,
+the hour, all chosen.
+
+**He never gets to make it.** The attack comes in the middle of the sentence, and
+the announcement dies with the man. Nor does it ever surface afterward: the midwife
+vanishes by dawn, the skeleton staff keep the silence they were paid for, and the
+inquest records a vanished *bride* — never a vanished *heir*. The world never
+learns what the ball was for. The only people who may ever know are players who
+earned the east wing, and what they do with a truth that exists nowhere else is
+the aftermath's sharpest knife (Chapter VI).
+
+Meanwhile, the ballroom guesses all night. The Merchant's Circle is *certain* the
+midnight pronouncement is a trade decree (the Tithe of Hands — see Agenda 1). They
+are wrong, but usefully wrong: the theory is plausible, the evidence for it is
+real, and the factions should argue it well. The truth is upstairs, eating dinner
+off the second plate.
+
+## The Other Player
+
+The second hidden power works through one agent: a tall, pale, soft-spoken man moving
+through the ball under the name **Master Vell**, a trade factor nobody quite remembers
+inviting. He is older than he looks, older than anything else in the palace, and he
+serves a patience so long that this night is, for him, one move among thousands.
+
+His task is the mirror of theirs: **the child must not be taken.** He is not here to
+save Raunu. He is not, strictly, here to save Veier. He is here so that when the worst
+happens, a wounded woman finds a strong arm, a clear path, and an unlocked river gate.
+Vell will not fight the Uninvited if he can avoid it — he knows exactly what they are,
+and they may know him. He prepares quietly, all night, and he is very good at it.
+
+Player characters who cross him find him courteous, unhelpful, and immune to every
+form of pressure. Player characters who help him, knowingly or not, are helping
+history happen.
+
+## How the Night Ends (By Default)
+
+Raunu Boranis is the most prepared man on Val'loh, and his preparations are the reason
+this attack does not become a massacre. The palace walls hold generations of stored
+crystal-work, and when the lights go out, those preparations fire: barriers seal
+corridors, light floods stairwells, wards flare over huddled guests. Two hundred
+people survive the Uninvited because a paranoid genius spent two silent years making
+his house ready for *something*.
+
+But he prepared for armies, poisons, rivals, and the Church. Not for this. When the
+moment comes, the last and best of his preparations has one charge in it, and Raunu —
+who has already understood, faster than anyone in the room, what the masked things
+have come for — spends it on his wife's escape instead of his own life. He dies on
+his own ballroom floor. It is a choice, not a failure, and if the players later piece
+that together, let them.
+
+Veier, wounded, goes out through the gardens on Master Vell's arm, through the river
+gate, into the dark. She will not survive the night; her child will. No player
+character learns this last part unless your campaign continues into the aftermath —
+what they see, at most, is a pale man carrying a bleeding woman toward the water,
+moving as if he has rehearsed it for years.
+
+By morning, three killers have vanished as if they had never existed, every great
+house prefers a version of events that blames a rival, the Church prefers no version
+at all, and the crime of the age begins its long life as an unsolved wound. Chapter V
+runs the attack in detail. Chapter VI runs the morning after.
+
+## What the Module Never Says
+
+Hold these lines even against clever players. Not because the answers are dull — but
+because the honest night is the one nobody walks out of understanding.
+
+- Where Raunu went in his missing year, and what he brought back.
+- Why this child, of all children ever born, is worth breaking a seal for.
+- The name of the power in the east, or of the power Vell serves.
+- What the mists are, or why they recede.
+- Who, precisely, the Uninvited were when they were people. (Their *grief* is
+  discoverable. Their names are not.)
+
+If a player asks a question that lands on one of these, the world answers the way
+the world would: with rumor, contradiction, and the cold satisfaction of standing
+at the edge of something vast.

--- a/adventures/oraga_night/03_Masks_and_Agendas.md
+++ b/adventures/oraga_night/03_Masks_and_Agendas.md
@@ -1,0 +1,267 @@
+# III. Masks and Agendas
+
+## Making Characters for Oraga Night
+
+Any Facets of Origin character works if they can plausibly stand in a ballroom without
+being arrested on sight. Characters are built normally (Chapter II of the Player
+Handbook), with these adjustments:
+
+- **Player characters are Orthaen** — or, in rare cases and with MM agreement,
+  **Phern** (a couple of high-ranking Phern sit on the Merchant's Circle, and their
+  factors and kin have legitimate business at the ball). This is an Orthaen affair;
+  the guest list is almost exclusively Orthaen, and anyone else would be watched
+  all night. Chapter VIII provides both tribes as packages that work exactly like
+  Backgrounds — a starting skill, a gift or secondary skill, and a Specialty — plus
+  the other tribes of Val'loh for the MM's use and for other adventures.
+- **Magic is different here.** There are no magic domains in this setting. The tribes
+  carry inherited gifts instead, and formal spellcraft is a slow, scholarly art useless
+  in a crisis. Chapter VIII has the rules; the short version is *gifts are always fast,
+  spells are never fast, and Orthaen crystals are the exception that runs this city.*
+- **Everyone gets an invitation story and an agenda** — see *How You Got In* and *The Agenda System*, this chapter.
+
+A party of Orthaen with at most one Phern is the expected shape. A Phern character
+is conspicuous — one of a handful of non-Orthaen faces in two hundred — which is not
+a problem but a spotlight, and the Merchant's Circle connection gives them a
+built-in patron. Five ready-made guests are at the end of this chapter.
+
+## How You Got In
+
+Every invitation is a story. Choose or roll (d6) during session zero:
+
+1. **Invited.** You are, or serve, someone prominent enough to be sent for by name.
+   You know what everyone whispers about this house, and you came anyway.
+2. **The entourage.** Someone among the invited needed a companion, a bodyguard, a
+   translator, or a witness. Their reasons for choosing you are their own.
+3. **The discarded invitation.** Many invitations were thrown away with theatrical
+   contempt — and a genuine Boranis invitation, under a mask custom, is as good as a
+   key. However you got yours, it has someone else's name on it.
+4. **Hired for the night.** House Boranis, its staff cut to the bone for two years,
+   quietly took on festival help: musicians, cooks, footmen, cellar hands. You are paid
+   staff with a servant's freedom of the halls — and a servant's invisibility.
+5. **The patron's errand.** One of the ball's factions (the Circle, the Church, a rival
+   sect, the Thenya) needed hands that could not be traced back to them. You come with
+   your agenda pre-loaded and your fee half-paid.
+6. **The wrong place, deliberately.** You have your own reason to be inside the Boranis
+   palace tonight, and the ball is simply the first night in two years the doors have
+   been open. (Work it out with the MM; the Unpaid Debt agenda below fits this well.)
+
+## Masks
+
+Every guest wears a spirit-mask until the midnight Unmasking. Mechanically, a mask is
+worth exactly what the fiction says it is worth: faces are hidden, voices are
+recognizable to those who know them, builds and manners give people away to a careful
+eye. Identifying a masked guest you know is **Standard** (Insight); one you have merely
+heard described is **Hard**. Behind a mask, approaching someone far above your station
+is **Easy** rather than Standard — the custom protects the conversation, and everyone
+at this ball is someone else tonight.
+
+Let players describe their masks. It matters to nobody and everybody, which is the
+correct proportion for a masquerade.
+
+## The Agenda System
+
+Each player character carries **one agenda** into the ball — a private goal with a
+patron or a personal stake behind it. Agendas are the engine of the first five
+Movements: while the night's events unfold on schedule, agendas give every character a
+reason to work the room, cross paths, and end up in the wrong corridor at the right
+moment.
+
+Deal agendas during session zero. Match them to characters, or hand them out face-down
+and let fate deal. Two players may share an agenda (rivals or partners — deal both
+ways). Every agenda card has:
+
+- **The ask** — what you were sent to do, in your patron's words.
+- **The catch** — the complication your patron did not mention.
+- **At midnight** — a private note on how this agenda changes when everything goes
+  wrong. Do not read this line to the player until the Unmasking.
+
+Agendas are written to be *completable before midnight* by fast, clever play — and the
+module rewards that. A character who finishes their agenda early has stopped being an
+errand-runner and started being a person who notices things. That is when the omens
+find them. **Completing an agenda earns a Spark** on the spot.
+
+---
+
+## The Eight Agendas
+
+### 1. The Circle's Reckoning
+*Patron: the Merchant's Circle, through Mistress Rhaza Callun.*
+**The ask:** Raunu has prepared some new trade decree — the Circle knows only that his
+ministers call it "the Tithe of Hands." Learn what it does before it is proclaimed.
+**The catch:** Nothing is written down — nothing ever is. The decree lives whole in
+exactly three heads: Minister Corval's and two ministers'. Corval is incorruptible
+by money. He is not incorruptible by kindness.
+**At midnight:** The decree lives only in the memories of men now trapped in a
+burning palace with three killers. Keep Corval alive and the Tithe survives the
+night; the Circle, to its own surprise, may end up owing you for saving the policy
+it hired you to undermine. *(The Tithe of Hands is a levy on each sect palace to pay
+festival laborers year-round — one more Raunu policy the great houses will hate. The
+module invents it here; it dies with its rememberers unless your table saves them.)*
+
+### 2. The Prelate's Question
+*Patron: the Church, through Prelate Damaris Kovaun.*
+**The ask:** The Church wants to know one thing, and will owe you a favor of
+frightening size for the answer: *is the man who came back the man who left?* Watch
+Raunu. Speak with him if you can. Bring the Prelate your honest judgment.
+**The catch:** The recluse will be seen perhaps four times tonight — a glimpse, a
+summons you must earn, a toast, and midnight. Miss a window and there may not be
+another. And then: your honest judgment. The Prelate will know if you shade it.
+**At midnight:** You are probably the only person in the palace who has studied
+Raunu's face all night. You saw the exact moment he understood — before anyone
+screamed, before the lights failed. He knew what they were. Remember that.
+
+### 3. A House's Long Game
+*Patron: House Draunel, through Lord Essar Draunel.*
+**The ask:** Vorlain Boranis ruled for a year and gave it back. Find out if he liked
+the taste. Get him to say something — anything — that House Draunel could later call
+an understanding.
+**The catch:** Vorlain is smarter than your patron believes, and afraid of his brother
+in a way your patron cannot imagine. He says nothing incriminating sober.
+**At midnight:** You know better than anyone in the palace how much Vorlain wanted
+this — and you watched his face when it happened. Whatever you saw there, you are the
+only witness to it.
+
+### 4. The Cousin's Errand
+*Patron: the Thenya delegation, through Maiven Nolonaire.*
+**The ask:** A message learned by heart — the law leaves no other kind — and her
+grandmother's ring to prove whose mouth it comes from, both for Veier Nolonaire
+alone: no minister, no husband, no exceptions. Bring back her answer, word for word,
+and bring back the truth: is she well, is she free, is she *herself*?
+**The catch:** Veier has not appeared in public for two years — and the ball is not
+going to show her at all. She never comes down. The east wing is closed, guarded,
+and the only way to her; this errand cannot be done from the dance floor.
+**At midnight:** She trusts you now — you are the one face at this ball she chose to
+trust. When she looks for help in the dark, she will look for you. *(This agenda puts
+a player character beside Veier at the Unmasking. Chapter V leans on it.)*
+
+### 5. The Unpaid Debt
+*Personal.*
+**The ask:** Your grandmother spent her working life growing a soul-crystal — a
+lifetime of light in a lattice the size of a heart. House Boranis took it in a border
+settlement two generations ago, and it hangs in their trophy gallery like a hunting
+prize. Take it home.
+**The catch:** The gallery is warded by the same generations-old crystalwork you are
+robbing, and tonight of all nights, the house's few guards watch it closely — the
+gallery is where the valuables are. And if the festival's quieter talk is true,
+you are not the only thief who noticed the first open Boranis door in two years.
+**At midnight:** The wards you have been studying all night flare to life around you —
+and you are the only guest who understands what the palace's defenses are doing, and
+where they are weakest. People will live or die by whether you share that.
+
+### 6. The Gate at Midnight
+*Patron: unknown.*
+**The ask:** A stranger paid you triple rates in old coin for one small thing: the
+river gate at the bottom of the garden is to be unlocked at midnight. Not before. No
+questions.
+**The catch:** You have no idea who paid you, why, or what comes through a gate — in
+which direction — at midnight on Oraga.
+**At midnight:** You find out. *(MM: the stranger was Master Vell, securing Veier's
+escape route. The player character who felt like a hired traitor all night was, in
+fact, the reason mother and child got out. Reveal this with care and full weight;
+few tables forget it. A table wanting a darker seam may
+rule the payer was scouting for the Uninvited instead; if so, Vell has a second route
+prepared, because he always does.)*
+
+### 7. The Story of a Lifetime
+*Personal.*
+**The ask:** The mist-tides are wrong. The silent house opens its doors. The chief who
+vanished throws a ball. Every thread you have followed for three years knots in that
+palace tonight — and in a world where nothing may be written down, a pattern lives
+only as long as the mind that holds it. Be there. Witness truly. Carry it out alive.
+**The catch:** True testimony has a way of making its carrier the most dangerous
+person in the city — to everyone.
+**At midnight:** You are the historical record now. What you choose to see in the
+next hour — and what you choose to hold in memory, or grow into crystal — is what
+Val'loh will ever know of this night.
+
+### 8. The Vanished Servant
+*Personal.*
+**The ask:** Your sister Anha took service in the Boranis kitchens four years ago. When
+the staff was cut four-fold, she was not among the dismissed — and the word she used
+to send home with the festival carters stopped coming. Two years of silence. Tonight the doors are open. Find her.
+**The catch:** She is alive, employed, and terrified — of nothing she can name. The
+skeleton staff are paid triple and forbidden to send word home, and none of them know why
+the east wing lights burn all night, or who the master talks to when the hall is
+empty. Finding her is easy. Getting her to talk, and deciding what to do with what she
+half-knows, is the night's work.
+**At midnight:** You know the service passages. When the corridors fill with smoke and
+locked doors, you and Anha are the only people in the palace who know the other way
+through — and two hundred guests are about to need it.
+
+---
+
+## The Ready-Made Guests
+
+Five pregenerated characters, one per agenda archetype, built on standard arrays
+(18 points, three Sparks, Endurance 4 + Constitution modifier). Tribe packages are in
+Chapter VIII. Hand them out as-is or let players reskin freely.
+
+### Serane Vaskarin — The Minor Scion *(Orthaen)*
+Fourth child of a middling branch of House Vaskarin: born close enough to power to
+know all its dances, far enough to be sent on its errands.
+**Attributes:** Str 1 (−1), Dex 2 (+0), Con 1 (−1), Int 3 (+1), Wis 2 (+0), Kno 2 (+0),
+Spi 2 (+0), Luc 2 (+0), Cha 3 (+1) — Endurance 3
+**Skills:** Persuade (Practiced, +1), Deceive (Novice, 1 mark)
+**Gift:** Orthaen soul-crystals — carries a few charged crystals (suggested: *steady
+light*, *seal a door*, *veil of quiet*). See Chapter VIII.
+**Specialty:** Sect heraldry and old grudges — knows who hates whom, and why, and since
+when.
+**Suggested agenda:** A House's Long Game, or The Prelate's Question.
+
+### Pello — The Factor's Nephew *(Phern)*
+A small, quick, cheerful man who has carried other people's valuables through five
+tribes' territory and lost none of them, including himself.
+**Attributes:** Str 1 (−1), Dex 3 (+1), Con 1 (−1), Int 2 (+0), Wis 3 (+1), Kno 2 (+0),
+Spi 1 (−1), Luc 3 (+1), Cha 2 (+0) — Endurance 3
+**Skills:** Finesse (Practiced, +1), Stealth (Novice, 1 mark)
+**Gift:** Phern danger-sense — see Chapter VIII. His neck has never once prickled for
+nothing.
+**Specialty:** Contracts, caravans, and smugglers' roads — who moves goods, and around
+which laws.
+**Suggested agenda:** The Circle's Reckoning, or The Gate at Midnight.
+
+### Andra Tessarin — The Pattern-Keeper *(Orthaen)*
+A lattice-scholar of a quiet Tessarin branch, who has spent three years growing a
+private record of a pattern nobody else believes is there: the mist-tides, the
+silent house, the strange marriage. In a world without books, Andra *is* her
+research.
+**Attributes:** Str 1 (−1), Dex 2 (+0), Con 1 (−1), Int 3 (+1), Wis 2 (+0), Kno 3 (+1),
+Spi 2 (+0), Luc 2 (+0), Cha 2 (+0) — Endurance 3
+**Skills:** Lore (Practiced, +1)
+**Gift:** Orthaen soul-crystals — a few charges (suggested: *hold an image*, *hold
+an image*, *chime at a threshold*). Her charges are her notebook.
+**Specialty:** The collected history of House Boranis — every public fact and most
+of the private ones, held in memory and lattice.
+**Suggested agenda:** The Story of a Lifetime.
+
+### Dassa — The House-Blade *(Orthaen, ungifted)*
+A hired blade of no house, who has guarded richer and softer people for twenty
+years. One Orthaen in five is born without the gift; Dassa has spent a lifetime
+being reminded of it politely, and has outlived several of the people who did the
+reminding. Slow to speak, impossible to move.
+**Attributes:** Str 3 (+1), Dex 2 (+0), Con 3 (+1), Int 1 (−1), Wis 2 (+0), Kno 2 (+0),
+Spi 1 (−1), Luc 2 (+0), Cha 2 (+0) — Endurance 5
+**Skills:** Combat (Practiced, +1), Endurance (Novice, 1 mark)
+**Gift:** None — and in a tribe four-fifths gifted, that has shaped every year of
+Dassa's life. The sword on her back is legal, customary, and larger than strictly
+polite.
+**Specialty:** Reading a room for exits, weapons, and the one person actually willing
+to use them.
+**Suggested agenda:** The Vanished Servant, or bodyguard to another player character
+(entourage entry).
+
+### Ilesse Kethaun — The Border Cousin *(Orthaen)*
+A courtier of House Kethaun's border branch, whose family has traded, feuded, and
+married across the Thenya frontier for five generations. Ilesse knew the Nolonaire
+name long before the rest of Rekuzan learned to gossip about it — which is exactly
+why a certain delegation, watched everywhere it goes, has quietly asked for an hour
+of Ilesse's evening.
+**Attributes:** Str 1 (−1), Dex 2 (+0), Con 1 (−1), Int 2 (+0), Wis 3 (+1), Kno 2 (+0),
+Spi 2 (+0), Luc 2 (+0), Cha 3 (+1) — Endurance 3
+**Skills:** Persuade (Practiced, +1)
+**Gift:** Orthaen soul-crystals — a few charges (suggested: *veil of quiet*, *seal a
+door*, *steady light*).
+**Specialty:** The Thenya border and the Nolonaire family — its history, its debts,
+and everything Veier was before Rekuzan.
+**Suggested agenda:** The Cousin's Errand. *(Of the five, this seat carries the
+most weight. Give it to a player who wants that.)*

--- a/adventures/oraga_night/04_The_Ball.md
+++ b/adventures/oraga_night/04_The_Ball.md
@@ -1,0 +1,722 @@
+# IV. The Ball
+
+*The palace, then the program. Movements I–V are this chapter; the Unmasking and
+everything after it are Chapter V.*
+
+## Palace Boranis
+
+The seat of House Boranis is grown, not built — pink crystal raised over generations by
+gifted ancestors, each of whom gave a working lifetime to a wing, a hall, a single
+perfect stair. It glows faintly after dusk, as all Rekuzan's old crystal does, and
+tonight it is lit deliberately for the first time in two years: lanterns in the
+gardens, fire in the great hearths, and the walls themselves shining like the inside
+of a shell.
+
+Guests notice two things within minutes. First, the splendor is real — House Boranis
+has spent lavishly, and the food, wine, and musicians are the finest of the festival.
+Second, the house is *empty*. A palace this size should hold a hundred servants;
+tonight, familiar liveried staff number perhaps two dozen, stretched thin and
+supplemented by festival hires who don't know where anything is. Whole wings are dark.
+The famous Boranis honor guard is present in bare ceremonial numbers.
+
+**Locations.** Eleven keyed areas in two tiers. **The Public Rooms** are where the
+ball happens — rumors are caught there, and the night's main events land there on
+schedule. **The Private Palace** is where the night's truths live — every room in it
+rewards investigation, and every Undercurrent runs through at least two of them.
+
+---
+
+### The Public Rooms
+
+*Each public room has its own gossip climate — roll the rumor table anywhere, but
+flavor the teller by the room: arrivals gossip at the gate, politics in the Crystal
+Court, household talk in the banquet galleries, dangerous frankness in the gardens,
+and policy in the Audience Hall, where people whisper about what they're waiting
+to ask for.*
+
+**B1. The Gatehouse Court.** Where invitations are presented — by name, against
+Minister Corval's memory, personally; there is no written list, and with Corval
+there has never needed to be. Nobody is disarmed at the door, because nobody is
+ever disarmed anywhere — see the sidebar below. *(Agenda relevance:
+forged and borrowed invitations are tested here. Corval is sharp, but it is dark, the
+line is long, and the custom of masks was made for this.)*
+
+> **Sidebar — Steel at the ball:** the Orthaen carry weapons the way other
+> peoples carry coin purses, and a festival ball is no exception. The custom is
+> small and concealed — a knife in the sash, a slim blade along the thigh — but
+> stronger personalities wear larger steel openly, and nobody thinks much of it.
+> Player characters can bring whatever they own. Anything short of enormous
+> draws no attention at all; enormous draws an occasional eyeroll; the only real
+> line is *brandishing* — bare steel pointed at a person — which brings guards
+> at a run and ends invitations (guard stat blocks: `enemies/boranis_honor_guard.fof`). That
+> House Boranis does not even try to disarm its guests unsettles the ones who
+> expected the paranoid recluse to insist: the house that prepared for
+> everything apparently does not care about your knife. Sit with what that
+> implies.
+
+**On first entry into the Crystal Court, read:**
+
+> *The room is a vault of rose-lit crystal and it is full of people. Dancers under a
+> gallery of musicians; a high table on a dais at the far end, laid and canopied and
+> empty. The walls give off a faint warmth where you brush them, like stone that has
+> been in sun all day. It has been dark for hours.*
+
+**B2. The Crystal Court.** The grand hall — a vault of rose-lit crystal that holds the
+whole ball: dance floor, musicians' gallery, the high table on its dais. The walls are
+the palace's oldest work, and guests who touch them feel a faint warmth, like a wall
+remembering sunlight. *(Nearly every scheduled event happens here.)*
+
+**B3. The Banquet Galleries.** Long feast halls flanking the Court, tables groaning
+with harvest excess. Where the real conversations happen, in alcoves built for
+exactly that. *(Best room for agenda work: everyone passes through, and the alcoves
+are half-private.)*
+
+**When the party first sees into the Audience Hall, read:**
+
+> *A smaller crystal chamber off the Court, lit for the first time in two years —
+> you can tell, because the light finds dust in the air that nobody has had reason
+> to disturb. A dais, worn down its centre. One chair. The room is quiet in the
+> particular way of a room that a great many people are deliberately not entering.*
+
+**B4. The Audience Hall.** A smaller crystal chamber off the Court, its dais worn
+by generations of petitioners — the room where Orthaen chiefs have always received
+the ruled. Dark for two years; tonight it is lit, and in Movement III Raunu holds
+audiences here, ministers screening supplicants through a screen so thin it is
+almost an invitation. *(Every agenda that needs the host runs through this room. The
+waiting line outside it is a scene in itself — rivals comparing masks and nerve,
+and everyone rehearsing their one question. In the aftermath wing, the inquest sits
+here, on the same dais, which no one who attended the ball finds comfortable.)*
+
+**B5. The Garden Terraces & the River Gate.** Lantern-strung gardens stepping down to
+the water, ending at a modest iron gate to the river walk — locked, always. Couples,
+conspirators, and anyone needing air. *(Agenda 6 lives here. So does the escape route.
+MM: know this geography cold — Court → terraces → lower garden → river gate.)*
+
+**When the party enters the Chapel, read:**
+
+> *Eight niches, one for each god, and the grandest of them is Fraden's as it is
+> everywhere. The room smells of cold wax and old smoke. Seven of the niches hold
+> what a house this rich would be expected to leave in them.*
+>
+> *The eighth has fresh offerings in it, and they have been tended recently, and
+> carefully.*
+
+**B6. The Chapel.** Where Raunu and Veier were married: an eight-niched chapel of the
+gods, Fraden's niche grandest as everywhere. But guests with sharp eyes notice
+that freshly tended offerings sit in *Elanna's* niche, the death-goddess northern tribes
+honor. Someone in this house has been sitting with mortality. *(Quiet scenes,
+confessions, and Mother Sella. A good place for players to catch their breath — and
+one deniable omen.)*
+
+---
+
+### The Private Palace
+
+*Getting into these rooms is the game: Anha's service passages, Corval's gratitude,
+an audience-earned pass, a festival hire's livery, or plain trespass with the
+consequences it deserves. Nothing in the private palace is guarded casually — and
+nothing in it is guarded the way the east wing is.*
+
+**B7. The Trophy Gallery.** The house's pride and plunder: banners, weapons, and grown
+crystals taken in old settlements — including a heart-sized soul-crystal of uncommon
+beauty (Agenda 5). Warded by old crystalwork; the few real guards concentrate here.
+*(Wards here are teachable: a character who studies them learns how Boranis defenses
+behave — light, seals, alarms — which pays off desperately at midnight.)*
+
+**B8. Raunu's Study.** Locked, dark wing, second floor. Two years of a genius's
+solitude, and — players will look for papers and find none, because there are none
+anywhere — the room thinks in crystal: instruments nobody can name, a grown relief
+of the eastern coast on the great table with its mist-lines remembered in colored
+lattice, the recent lines reworked many times; a work-slate bearing a half-erased
+lattice diagram (temporary scratch-work, the one grudging medium even the law
+cannot police); and, the detail that should follow players home, a drawer of
+duplicate invitation cards, one for every guest, a certain few with a corner
+deliberately scorched, as if he had been deciding something about each one. *(The
+module does not explain the instruments or the scorch-marks. Operational hint only:
+Raunu has been studying something far away to the east, and preparing. Nothing of
+Agenda 1's decree is here — the Tithe of Hands exists only in Corval's memory and
+two ministers'.)*
+
+**When the party first comes within sight of the east wing doors, read:**
+
+> *Double doors, closed, and more guards on them than the rest of the palace is
+> using put together. The corridor in front of them has been cleared of furniture.
+> Nobody is walking down it, and nobody has been told not to.*
+
+**B9. The East Wing — the Living Quarters.** Sealed, guarded, forbidden — and behind
+its doors, the warmest rooms in the palace, or the saddest, depending on when you
+learn what you learn. Warm light, a midwife's quiet traffic, and three finds:
+
+- **Veier's rooms.** Thenya through and through: border-country wool over Orthaen
+  crystal, pressed mountain flowers, a sling and shot worn smooth with actual use.
+  And, telling its whole story without a word: her traveling pack. For the first
+  year (the servants' silence confirms it, if Anha talks) it stood packed by the
+  door, ready, a border woman's plain statement that she could leave whenever she
+  chose. It stands there still, out of habit or humor — but it is empty now, and
+  its contents have quietly become the room: the wool folded onto the marriage
+  bed, the flint on the mantel, the mountain flowers pressed and kept. She stopped
+  being ready to go home. *(For the Agenda 4 player, reading this room before
+  meeting her changes everything about the errand — and makes the message they
+  carry feel suddenly heavier.)*
+- **Raunu's rooms.** Nearly bare — a soldier's cot in a palace, which fits nothing
+  anyone believes about him. Two personal objects only. A small, flawed, badly-grown
+  crystal, decades old, kept on the sill where the light finds it: his first, grown
+  at six, and kept the way other men keep nothing. And beside the worn border
+  sling that is obviously hers: a second sling, new, its knots clumsy,
+  re-tied many times — the terror of the Orthaen learning his wife's weapon,
+  badly, in private, presumably to laughter. *(Behind the last guarded door, the
+  marriage everyone in the ballroom is pricing as a transaction is just a
+  marriage.)*
+- **The nursery.** Newly and beautifully made, fresh paint and cedar, a mobile of
+  grown crystal turning slowly over the crib. *(This is the palace's most explosive
+  secret, all night — the announcement that would have made it public never gets
+  made. Agendas 4 and 8 and Undercurrent C can reach it. In hindsight, this room is
+  the night's most devastating.)*
+
+**B10. Kitchens & Service Passages.** Understaffed chaos, festival hires, and the
+skeleton staff of two silent years — including Anha (Agenda 8). The service passages
+thread the whole palace, including the east wing and the garden stair. *(The other way
+through everything. At midnight, the difference between a tragedy and a massacre.)*
+
+**B11. The Root of the House.** *(Hidden. Found only through Undercurrent A — The Root of the House, this chapter.)*
+Beneath the wine cellars, behind a seal of living crystal, lies the oldest place in
+Rekuzan: the chamber where the first Boranis ancestor grew the first crystal of the
+palace, centuries of house rising from this one root. Raunu has made it his true
+workshop. What waits inside is described in Undercurrent A — and at midnight, the Root
+matters again: the palace's defenses are deepest here, and a character who understands
+the wards (Agenda 5, or study in this room) can *steer* them from the Root the way
+Raunu does from memory.
+
+## Running the Room
+
+Two hundred guests, fourteen of them named (Chapter VII). Between scheduled events,
+run the ball as a loop of **approaches**: a player character seeks someone out, or is
+sought out — patrons checking on agendas, rivals testing masks, strangers flirting,
+Vorlain's cousin Essin recruiting drinking companions who might talk. Every named NPC's
+entry lists where they stand in each Movement; the night-tracker in Chapter IX puts it
+on one page.
+
+**Rumors** circulate all night: any social scene can yield one (roll on the table in
+Chapter IX, or choose). They are contradictory by design. Nobody at this ball knows
+the truth. Not even you.
+
+---
+
+## Trouble You Can Walk Into
+
+No fight at this ball is mandatory — and every fight at this ball is *visible*.
+That is the rule of this section. A table that wants an evening of pure fencing-
+with-words never has steel forced on it; a table with restless sword hands should
+keep catching sight of trouble it could choose to join. Three troubles circulate
+below. Show them plainly, once each, the way you show an omen — and then let them
+be walked into, or past.
+
+### The Seating Feud *(Movements II–IV, the Banquet Galleries)*
+
+Corval's escalating seating feud — the one a kind player character may already have
+helped him with — loses its manners at dinner. A Vaskarin cousin and a Tessarin
+uncle, each certain their branch outranks the other, have been moved twice apiece
+by the exhausted staff, and somewhere between the first course and the second the
+argument stops being about chairs. Raised voices. A circle forming. A cup thrown,
+then a bench going over — and two knots of kinsmen and hangers-on wading in behind
+their principals, masked, drunk, and delighted for an excuse.
+
+This is an honest brawl, and anyone can join it: fists, elbows, harvest fruit,
+someone's ceremonial staff — combat rules as written, all of it Tier 1 bruising.
+The one line is the ball's own: **bare steel** turns a scuffle into a scandal and
+brings guards at a run (see the sidebar below). Player characters can pick a side,
+shield the innocent, or end it — hauling the principals apart, a Commanding
+Presence, a well-timed joke at both houses' expense. Ending it *well* earns
+Corval's open gratitude, which is worth more than either house's: he is the man
+who opens doors. Letting it run costs nothing but bruises and reputations — and
+fills the galleries with guards for a Movement, which some agendas will find
+inconvenient and one crew (below) finds very interesting indeed.
+
+### The Other Thieves *(Movements III–VI — one trouble in three sightings)*
+
+Tavva's crew (Chapter VII; `enemies/tavva.fof`, `enemies/gallery_knife.fof`) is working the ball tonight,
+and a watchful table can catch them at it three times. Each sighting is shown
+plainly, once; each can be followed, braced, or let go. They are professionals:
+they fight to leave, not to kill, and they are entirely winnable — the module's
+one promise of a fight a starting party can flatly win tonight.
+
+- **The scout** *(Movement III)*: a footman crosses the gallery corridor carrying
+  an empty tray in livery that fits him like a borrowed coat — and he is counting
+  the trophy gallery's guards on his fingers, which no footman needs to do.
+  Followed, he leads to two more of the crew idling near the service doors.
+  Braced quietly, he bluffs badly, then bolts; braced loudly, the crew scatters
+  into the crowd and Tavva changes her timetable, wondering who else is working
+  her gallery tonight.
+- **The staging** *(Movement V)*: during the Dead Dance, in the lowered lamps,
+  figures moving through the dark service corridors with rope, sacking, and a
+  shuttered lantern — visibly *not* dancing, visibly not staff. This is the last
+  quiet chance to stop what is coming, and the only one where the whole crew is
+  in one place. A fight here is knives in the dark, hushed on both sides —
+  because whoever makes noise answers to the guards, and both sides know it.
+- **The raid** *(Movement VI–VII)*: see Chapter V — when the lights die, the crew
+  goes to work, and stopping them becomes a thing worth doing in front of
+  witnesses.
+
+*(Agenda 5's player has a private stake in all three sightings: the crew's list
+and their grandmother's crystal hang in the same gallery.)*
+
+> **Sidebar — Guards are a scene, not a sentence:** when player characters cross
+> the house — a heist gone loud, the east wing forced, steel bared in the feud —
+> the guards who answer are a *playable fight*, not a fail state. Run two or
+> three exchanges of detain-and-expel (`enemies/boranis_honor_guard.fof`; they subdue,
+> they do not kill), and keep the outs visible: surrender costs the evening but
+> not the character; the service passages swallow anyone quick enough to reach
+> them (a chase on Body rolls); a good name dropped — a patron, a kindness done
+> to Corval — can end the scene in an escort back to the party and a warning.
+> The win condition is the getaway, and a clean getaway is absolutely on the
+> table. For a table hungry for honest combat, the house's own guards are the
+> honest opponent: real, dangerous, and survivable.
+
+---
+
+## The Undercurrents
+
+Four investigations run beneath the ball — mysteries a curious table can *solve*, or
+at least reach the bottom of, before midnight solves everything its own way. Each
+Undercurrent has a **spark** (how players catch the scent), a **trail** (redundant
+clues — a table that misses one finds another; never let a single failed roll close a
+thread), a **find** (what's at the bottom), and **at midnight** (how the discovery
+pays off when the lights die).
+
+Agendas are what the characters were *sent* to do. Undercurrents are what they
+*choose* to chase. The module's best nights are the ones where a player abandons
+their patron halfway down a wine-cellar stair.
+
+### Undercurrent A — The Root of the House
+*There is a sealed place beneath the palace, and the master keeps it himself.*
+
+**The spark:** rumor 5 ("he slept a year in the root of the house"); or Anha's
+forbidden corridors — she is barred from sweeping the *lower* cellar stair, which
+makes no sense, because nothing is down there but wine; or a sharp eye in the study
+(B8): the half-erased lattice diagram on Raunu's slate matches no door anyone has
+seen upstairs.
+
+**The trail:**
+- *The kitchens (B10):* the cellar tally-cords don't add up — for two years, supplies
+  have gone down the lower stair that never came back up as anything. Candles by the
+  crate. Lamp-oil. And once, memorably, a crate from the eastern coast that hissed
+  when it shifted, packed in salt. (Anha, befriended, offers this unprompted; a
+  festival-hire cellar hand can be charmed into showing the knots instead.)
+- *The wine cellar:* the far wall is older than the rest — living crystal, faintly
+  warm, with a seam in it that is not a crack. Finding the seam is Investigate
+  (Standard; Easy for anyone who saw the study's lattice diagram). The seam is a
+  **door**, and it is sealed the way Boranis things are sealed: grown, not locked.
+- *Opening it:* the lattice diagram from the study is the key — literally; traced on
+  the seam it opens (automatic if a player copied or memorized the slate; Attune at
+  Hard to improvise it from ward-study, e.g. Agenda 5's gallery work). Brute force is
+  worse than useless: the Root's wards answer, and the house's few guards arrive with
+  real fear on their faces — nobody but the master goes down there.
+
+**The find:** Raunu's true workshop, and it is *beautiful* — no torture-vault, no
+horror, which is somehow more unsettling. A grown-crystal chamber lit from within,
+and everywhere the evidence of one sustained, forbidden inquiry: **the source of the
+gifts.** What an hour in the laboratory yields, in rising order:
+
+- **The recall-lattices.** In a world where the written word belongs to the Church,
+  this room is a hoard of knowledge with no equal outside its vaults — and it is
+  made entirely of crystal: racks of grown lattices, decades of research held in
+  light. Touch one
+  and it *shows* rather than tells — structured sequences of image and remembered
+  gesture, gift-workings demonstrated by hands long dead, tribal lineages branching
+  like rivers. Many of the oldest lattices are not his work: relics, acquired
+  quietly through Phern intermediaries over fifteen years, at prices that would
+  frighten the Circle. All of it — a character who samples even three or four
+  lattices sees it — bends toward one question: **where do the gifts come from?**
+- **One lattice that speaks.** Among the racks, a crystal that holds a voice —
+  Raunu's own, dry and private, a man thinking aloud into stone because the law
+  left him nowhere else to put it: *"The Church says the gifts are given. Wrong
+  verb. The gift is not given. It is remembered."*
+- **Instruments** of glass and lattice nobody can name — but an Orthaen or an
+  Attune-inclined character can *feel* what they do: they read the gift itself, the
+  way a jeweler's glass reads a stone. Reading the gift in what, the room answers
+  quietly: a chair with a wide armrest, a stool beside it, a lap-blanket of Thenya
+  wool folded over its back.
+- **The skeleton.** In an alcove the lamplight has to be carried into: a full human
+  skeleton laid out on a stone bier, and through every bone of it — threading the
+  ribs, veining the long bones, clustered like frost in the eye sockets — grow
+  **fine-grained crystals**, seeded and cultivated through the marrow itself. It is
+  not violence; the bones are old, unbroken, and arranged with something like
+  respect, and the crystal-work is years of patient tending. An Orthaen or a
+  scholar who studies it grasps the experiment's question, because the whole room
+  has been asking it: *does any remnant of the gift survive death?* Whether the
+  crystals found an answer, the lattices do not legibly say — a few threads in the
+  ribcage glow, very faintly, if no one is speaking. Whose bones these are, the
+  module does not know, and the room does not tell. It is the exhibit that shows,
+  more plainly than anything else in the laboratory, how far down this road Raunu
+  Boranis was willing to walk. *(Let the table sit with it. Then let them notice
+  the observation lattices beside it, and do the arithmetic between a man who
+  studies the gift in the dead — and one who studies it in the not-yet-born.)*
+- **Dated observation lattices**, months of them, in meticulous sequence — the
+  measurements of a gift being studied over time, growing week by week. The
+  sequence begins about eight months ago. The latest plate is the finest work in
+  the room, grown with a care that has stopped being science.
+- **The coast in crystal** — a grown relief of the eastern shore and its
+  mist-lines going back four centuries, the recent lines reworked many times.
+- And at the center, the piece no one forgets: **a crystal orrery of two family
+  trees** — the Boranis line and the Nolonaire line, rendered in light, ancestry
+  descending generations deep, intertwining as they descend, both converging
+  toward a single darkened junction older than either house, where one name has
+  been deliberately, physically *burned out* of the lattice. And woven into the
+  orrery's base, in the private pattern-language the rest of the room refuses to
+  yield, one figure repeats over and over — two streams of light falling into a
+  single pool. A Scora, or anyone who takes an hour with it, can read the figure
+  the only way it can be read:
+
+> *Both rivers, one spring.*
+
+The shape of it is discoverable, and the module intends tables to discover it: the
+chief of the Orthaen believed the gifts of two tribes were one gift, long ago —
+that his marriage carried both halves — and that he has spent eight months
+*watching the proof grow.* What the module still does not give: the lattices'
+deeper contents, the name burned from the junction, what the restored gift is or
+does, or what the mists have to do with any of it. The find is a door left ajar on
+something vast — and it is also, quietly, why rumors 2 through 12 all exist:
+everyone senses he was *doing something*. Nobody guessed this.
+
+**At midnight:** three payoffs. The Root is the strongest-warded place in the
+palace — a safe room that can shelter a dozen guests through the whole attack. A
+ward-literate character can steer palace defenses from here (seal a corridor ahead
+of the Radiant; light a stairwell for the fleeing). And the Uninvited *will not
+enter it* — whatever the deep crystal is to them, they will not cross its
+threshold, a fact the module states and does not explain.
+
+### Undercurrent B — The Household That Wasn't
+*Eighty servants left this palace two years ago. Where does eighty of anything go?*
+
+**The spark:** Agenda 8; or the festival hires — one of tonight's borrowed footmen
+*used to work here*, recognized by his ease in the corridors; or simple arithmetic
+by any guest who has run a household.
+
+**The trail:** the returned footman, cornered kindly, tells his strange story: paid
+off two years ago at triple severance, sworn to silence on the house's affairs, and
+*relocated* — passage and placement found for every one of them, most to holdings
+far from Rekuzan. He came back tonight on a festival hire because he missed the
+place, and he is frightened to be recognized. Corval (via Agenda 1's kindness
+route, or a well-aimed question once his guard is down) confirms it — and here the
+majordomo's famous memory becomes the scene: he can recite all eighty placements,
+each with the master's spoken instruction verbatim: *this one has a mother in
+Kethaun lands; this one wants a smithy; this one drinks, place him somewhere dry.*
+And, three days before the ball: the testament Raunu swore aloud in the chapel,
+Corval and Mother Sella standing witness as the law requires, providing for every
+current servant by name.
+
+**The find:** nothing sinister — and let the table feel the floor tilt as that lands.
+The staff weren't victims. They were *evacuated*, with a thoroughness that reads as
+love expressed as logistics. The silent palace was never hiding a crime. It was
+clearing the decks. For what, neither Corval's memory nor the testament says.
+
+**At midnight:** the players who solved this one understood the night *before* it
+happened — and they know the skeleton staff who remain are the ones Raunu judged he
+could not make leave. Corval, Anha, the nine inward-facing guards: the volunteers.
+Every one of them saved is a coda this thread earns.
+
+### Undercurrent C — The Third Plate
+*Two people live in the east wing. The kitchen sends up meals for two. Lately the
+trays come back down — three plates used.*
+
+**The spark:** Anha mentions it as one of her unframed facts; or laundry — a guest
+near the service passages sees linens going up that no ball needs: small, soft,
+new-hemmed; or rumor 11's "guards on the inside of the doors" invites a test that
+finds the guards courteous, immovable, and *protective* rather than jailerly.
+
+**The trail:** the midwife, the third plate herself, glimpsed once crossing the gallery at
+the end of Movement II, moving like a woman who counts hours. Following her to the
+east wing doors is easy; through them needs Agenda 4's errand, Anha's passages, or
+real ingenuity. Inside: warm light, the guarded calm of a household holding its
+breath, and the living quarters' three finds (B9) — the unpacked traveling pack,
+the two slings, and the nursery with its slow-turning crystal mobile. The pregnancy
+is the thread's answer; the pack and the slings are its heart, and a table that
+reads those rooms stops investigating a scandal and starts guarding a family.
+
+**The find:** the pregnancy — the secret the whole ball is guessing at, and the
+sentence Raunu will die without finishing. He means to announce it at midnight;
+he never gets to; so the players who bottom this thread may be the *only guests
+in the palace* who ever know what the night was for. What a player *does* with
+that is the thread's real payload: sell it (the Circle would reprice the room),
+guard it, warn the Thenya, or carry it silently into the Unmasking knowing what
+the recluse is about to say. The players who found the nursery tend to appoint
+themselves its protectors, which is exactly where Chapter V wants them standing.
+
+**At midnight:** knowing the east wing's layout, its inner guards by name, and its
+service-passage doors makes a character the most useful person in the palace the
+moment the Radiant starts up the gallery.
+
+### Undercurrent D — The Guests Who Cast No Gossip
+*Two hundred masks, and every one of them trails rumor like perfume. Except three.*
+
+**The spark:** Corval's failing count (Movement III omen — his memory has never
+once lost a guest, until tonight); or Corro's misfiring gift; or the simple social
+fact — nobody is talking *about* the three gray masks, which at this ball is
+against nature.
+
+**The trail:** built from the cast's planted tells, and best walked with allies —
+Corval, pressed, discovers he cannot keep the question in his head and becomes
+frightened of his own mind (a superb scene: the unflappable majordomo asking a
+guest to *hold the thought for him*); Corro, walked deliberately around the room,
+is worst near the three — a living compass reading he refuses to interpret; Otta
+Vesh's recall and her wall of casting-blanks (prelude wing), or any guest's
+craft-eye, confirms the gray masks match no maker's style in Rekuzan, and the
+material is wrong; conversation with them turns up speech and manners a century
+dead, delivered by warm, living, charming people; and any Orthaen who stands near
+one feels their own carried crystals go faint and quiet. Each clue is deniable.
+Three together are not. *(These same encounters are where Fracture ammunition
+comes from — the tells are listed with the Fractures in Chapter V, and every one
+of them can be met before midnight.)*
+
+**The find:** certainty, before midnight, that three guests are impossible — on
+no one's list, in no maker's masks, speaking a century that isn't this one — the
+only Undercurrent whose bottom is a warning instead of an answer. What then?
+Warning Corval gets the east wing guard doubled (it already will be; now the
+players know *why*). Warning Raunu is the thread's crown: he listens — completely,
+the way he listens to everything — thanks them with terrible gentleness, and does
+not act. *"I know," he says. "You noticed. That matters more than you yet
+understand. Enjoy the ball — and stay near the walls after the bells."* (He has
+understood for one Movement longer than the players; what he is already doing
+about it is Chapter V.) Confronting the three directly gets perfect, wrong
+courtesy, and if pressed to a scene, they simply leave it — through the crowd,
+unhurried, unfindable for a Movement — and the accuser stands in the wreckage of
+their own credibility.
+
+**At midnight:** everything. Fracture ammunition (Chapter V) is this thread's
+currency; players who walked it enter the Longest Night armed, positioned, and —
+rarest of all at Oraga — *unsurprised*.
+
+> **Sidebar — Threading the clock:** Undercurrents are paced for Movements II–V.
+> If a table locks onto one early and bottoms it by Movement III, let it ripple:
+> foreknowledge changes their Movement IV, and the module's scheduled events keep
+> arriving regardless. If a table chases none of them, the omens still fire, the
+> agendas still collide, and the night still works — the Undercurrents are the
+> depth, not the floor.
+
+---
+
+## The Program of the Night
+
+### Movement I — The Receiving Line *(dusk)*
+
+The gates open at last light. Minister Corval receives each guest by name at the
+Gatehouse Court — a thin, upright old man doing the work of six chamberlains with
+visible, dignified exhaustion. Masks go on at the door; blades stay where their
+owners like them. The line is long, and it is the best gossip hour of the year.
+
+**When the party comes up the approach and the palace first comes into view, read:**
+
+> *The whole hill is lit. Not lamps — the walls themselves, rose-coloured and faintly
+> warm, so that the crystal of Palace Boranis stands against the dark like something
+> holding its breath. Music reaches you before the gate does. So does the smell of
+> two hundred people's best perfume and a harvest kitchen working at capacity, and
+> under both of those, very faintly, cold stone.*
+>
+> *The line ahead of you is long and in no hurry. Every face in it is already a mask.*
+
+**When they reach the head of the line at the Gatehouse Court, read:**
+
+> *A thin old man in Boranis livery takes each guest in turn, greets them by name
+> without looking at anything written down, and passes them through. He has been
+> doing this for an hour and his hands are steady. Nobody ahead of you has been
+> asked to give up a blade.*
+
+**Scheduled:** arrival, first sight of the lit palace, the slow realization that
+nobody is checking anyone for steel. Neither Raunu nor Veier appears. The high
+table stands empty under its canopy.
+
+**Agenda beats:** forged invitations tested (B1); staff hires slip in through the
+kitchens (B10); patrons make contact and confirm asks; first reconnaissance.
+
+**The omen:** the honor guard. A house this rich should field forty blades in
+ceremony. There are nine. A soldier or bodyguard (Brakka's Specialty is built for
+this) counts them without trying — and notes that the nine are placed *inward*, facing
+the palace doors, not the gates.
+
+### Movement II — The Empty Rooms *(early night)*
+
+The ball proper: music in the Crystal Court, feasting in the galleries, lanterns on
+the terraces. The host has still not appeared, and his absence becomes the room's
+running joke, then its running unease. This is the longest Movement — let agendas
+breathe here.
+
+**Scheduled:** Vorlain holds court by the wine with practiced charm (Agenda 3's
+window). Prelate Kovaun works the room like a man taking a census of souls. Mistress
+Callun and Master Corro compare margins in a gallery alcove. Maiven Nolonaire asks,
+with thinning patience, when the delegation will be received.
+
+**Agenda beats:** Corval can be befriended (Agenda 1) by anyone who actually helps
+him — he is drowning in understaffed logistics and has forgotten what kindness costs.
+Anha found in the kitchens (Agenda 8). The gallery wards studied (Agenda 5). The east
+wing's guarded doors scouted (Agenda 4).
+
+**The omen:** Master Corro — the Phern magnate, whose tribe's danger-sense is
+proverbial — keeps losing the thread of his own sentences and glancing at doors. Asked
+about it, he laughs it off: *"Old instincts. Crowds."* His hands say otherwise. His
+gift is ringing like a struck glass and pointing nowhere.
+
+### Movement III — The Summons *(mid-night)*
+
+The host does not appear. This is the Movement where the ball fully absorbs that he
+may never appear — the guests came to see the recluse, and the recluse is declining
+to be seen. Some guests glimpse him exactly once: a still figure on the high gallery
+above the Crystal Court, watching the room the way a man watches weather, gone when
+they look again. The ball's mood curdles from curiosity into something between
+insult and dread, and the gossip gets markedly worse.
+
+Then Corval begins fetching people.
+
+**When a character is walked into the Audience Hall, read:**
+
+> *The hall is bigger than it needs to be and almost entirely empty. Crystal walls,
+> unlit at the edges, throwing back a little of the light from the door behind you.
+> A dais at the far end, worn smooth down the middle where several centuries of
+> people have knelt. One chair on it. Somebody is sitting in the chair, and the
+> length of the room is between you and them.*
+
+**Scheduled:** the Audience Hall (B4) is lit for the first time in two years — and
+stands empty, which is its own kind of omen. One at a time, at long intervals,
+Minister Corval quietly approaches a guest and says the sentence nobody expected:
+*"The master will see you."* Inside the vast, bare hall: one chair on the dais,
+occupied, and a long walk toward it. Raunu summons perhaps four guests all night.
+**At least one, preferably two, should be player characters** — chosen not by rank
+but by whatever drew his attention: an agenda that brushed his interests, a kindness
+done to his majordomo, a question asked too well. Being summoned is an honor, a
+threat, and a mystery, and the rest of the ball watches who goes in.
+
+Play the summons per Chapter VII: this is not the warm charmer of anyone's
+expectations. He is awkward in the way of a man who has forgotten the shapes of
+small talk and declines to fake them — long pauses, no pleasantries, the true thing
+said where the polite thing was expected. And he knows things he should not know
+(the guest's agenda patron, their grandmother's crystal, their sister in his
+kitchens), and shows it without threat, almost absently. He is *sounding* people —
+though for what, he does not say. Each summons ends the same way: abruptly, with
+something that is nearly a kindness, and the long walk back.
+
+**Agenda beats:** a summons is the only route to the host — Agenda 2's one close
+study, Agenda 1's one chance to simply *ask* (which gets a long look, and then,
+flatly: *"It taxes palaces to pay laborers. The palaces can afford it. That is the
+whole secret. You may tell the Circle I said so."*). Agenda 4 may ask after Veier —
+he goes still for a moment, then: *"She chooses her guests herself these days. If
+she chooses you, you will know."* Characters not summoned work the room — angling
+to *get* summoned is a fine scene in itself.
+
+**The omen:** three guests in spirit masks — gray, unornamented, beautiful in a way
+nobody can place. Nothing about them is visibly wrong. They eat. They drink; one
+praises the wine in a turn of phrase nobody's grandmother would be old enough to
+use. They are gracious, well-mannered in a slightly antique way, pleasant to talk
+to — and nobody remembers them arriving, and Corval, asked, cannot account for
+them (his perfect memory of the invitations simply slides off the question), and
+then, oddly, cannot hold the question in his head long enough to be alarmed by it.
+*(These are the Uninvited. They arrived with the evening's thickest crowd. They
+will do nothing at all until midnight — they are waiting for the one moment custom
+guarantees the recluse must appear. Players may approach them; see Chapter VII.
+Conversation with them is genuinely pleasant, which is, afterward, the part
+nobody can stop thinking about.)*
+
+### Movement IV — The Toast *(later — dinner)*
+
+The banquet is called, and the galleries fill. And then, between the first course
+and the second, with no trumpet and no announcement, Raunu Boranis is simply
+*standing at the high table* — unmasked, plainly dressed for a chief, holding a cup
+as if someone had handed it to him and left. The room takes a full three seconds to
+notice. Then it takes a breath, all at once.
+
+The toast should be delivered word-for-word, pauses included:
+
+> "Thank you for coming. I know why most of you came.
+>
+> *(a pause that goes on too long — he looks at the room the way he looked at it
+> from the gallery)*
+>
+> The harvest was kind. The food is very good. To the ones we lost.
+>
+> *(he drinks; the room, a beat behind, drinks; he does not sit down)*
+>
+> At the Unmasking, I will have something to say. Something two years in the
+> keeping. Midnight is the right hour for it.
+>
+> Enjoy the food."
+>
+> And then Raunu Boranis, chief of the Orthaen, gathers **two plates** from the
+> high table — filling both himself, carefully, taking his time about it, the whole
+> hall dead silent — and walks out through the east doors, and does not come back.
+
+The doors close. One heartbeat. Then the room boils — not with news, but with the
+*promise* of news. Two years of silence, and the recluse has just scheduled its
+ending to the hour. Nobody in the ballroom will ever learn what he meant to say.
+The ball spends its last hours guessing at a sentence that will never be finished.
+
+**Agenda beats:** the guessing is the Movement. Callun and the Circle are certain
+it is the trade decree — the Tithe of Hands, announced at midnight to a captive
+audience of everyone it will fleece (they are wrong, and their certainty is the
+module's best red herring, because it is so *plausible*). Draunel fears a
+succession decree; Kovaun's question acquires teeth; Vorlain goes quiet and drinks.
+And everyone saw the two plates. The gossip about the two plates is feral — he
+feeds the mad wife, he feeds a prisoner, he feeds the thing in the east wing —
+and only players who have run Undercurrent C know the tender truth of it. For
+Agenda 4 and the Thenya, the night sharpens: still no Veier, and now a midnight
+pronouncement coming. Maiven formally requests an audience; Corval, with genuine
+misery, declines. The east wing (B9) is the only way to her, and Undercurrent C
+is the map. *(Players who reach Veier after the toast find her eating dinner with
+her husband. It is the only time anyone sees the two of them together; stage it
+with all the warmth the ballroom's rumors deny them.)*
+
+**The omen:** the falconry mews behind the garden wing erupt — every bird screaming
+at once, then, worse, all at once silent. The gardens go quiet the way a forest does
+when something walks through it. Guests laugh it off. Master Corro, and any Phern
+player character, does not.
+
+### Movement V — The Hour of Spirits *(approaching midnight)*
+
+The old custom, and the palace keeps it in full: the lamps are lowered, the music
+turns slow and strange, and the **Dead Dance** begins — every guest masked, dancing
+with whoever the dark provides, living and dead alike, until the midnight bells. It
+is the most beautiful hour of the Val'loh year. Tonight, with the walls glowing
+faintly rose and two hundred spirit-faces turning in the gloom, it is also the
+easiest hour in the world to move unseen.
+
+**When the lamps go down for the Dead Dance, read:**
+
+> *The lamps come down until the only real light is the walls, and the walls are
+> the colour of the inside of a shell. The music slows into something with a much
+> older shape to it. All around you the spirit-faces turn — you cannot tell who
+> anyone is, and neither can they, and that is the point of the hour. Somewhere
+> above, a bell strikes a quarter.*
+>
+> *A hand is offered to you out of the dark, and the figure is beginning.*
+
+This hour is the night holding its breath. Run it slow. Every player character is
+somewhere, with someone, in near-darkness.
+
+**Scheduled:** the Dead Dance; the bells begin their quarter-tolls toward midnight.
+And running under everything, the fact the whole ball knows and the players should
+be told: **custom demands the host lead the Unmasking.** Whatever else Raunu
+Boranis has dodged tonight, at midnight he must stand on that dais, send the
+spirits home, and toast the living year with his own face. It is the one appearance
+the recluse cannot refuse — the one moment of this entire night anyone could have
+predicted him. Guests are already drifting toward the Crystal Court to watch.
+Corval quietly doubles the guards on the east wing — noticed only by players watching
+for it. Master Vell, who has spent the whole ball being unmemorable, walks the garden
+terraces once, alone, and stands a while at the river gate. *(If Agenda 6's gate is
+unlocked, he confirms it and leaves it so. If a player refused or reported the
+strange commission, he unlocks it himself — he always has a second way.)*
+
+**Agenda beats:** last chances — the study (B8), the gallery (B7), the errand's
+answer, Anha's testimony. Any agenda not yet closed should reach its crisis here, in
+the dark, mid-dance.
+
+**The omen — the last one:** a player character dancing in the Dead Dance finds
+their partner is one of the gray masks — the tall one, the one with carved tears.
+She dances flawlessly, in a style generations out of fashion; her hands are warm
+and sure; and near the turn of the figure she says one thing, softly, like a
+person being kind to herself: *"You dance like my daughter would have."* Then the
+dance turns them apart. *(Give this to any player — it needs no positioning; it
+is sorrow ammunition, and it will follow them home either way.)*
+
+Then the bells reach midnight. The east doors open, and — as custom has commanded
+every host of every Oraga since the first — Raunu Boranis walks back into the
+Crystal Court and mounts the dais to lead the Unmasking, before two hundred guests
+and three that no one invited.
+
+*Go to Chapter V. Everything sets off in the middle of his speech.*

--- a/adventures/oraga_night/05_The_Longest_Night.md
+++ b/adventures/oraga_night/05_The_Longest_Night.md
@@ -1,0 +1,397 @@
+# V. The Longest Night
+
+*Movements VI and VII: the Unmasking, the attack, and every way it ends.*
+
+## How to Run the Attack
+
+Drop the social rules and run the crisis in **beats** — short scenes cutting between
+player characters, each beat one question: *what do you do?* Facets of Origin combat
+rules apply when someone fights, but this is not a set-piece battle. It is a burning
+building with three killers out of another age in it, two hundred civilians, and a
+handful of people — the players — capable of choosing anything at all.
+
+Three principles:
+
+1. **The Uninvited have a task, not a body count.** They kill whoever stands between
+   them and Raunu, Veier, and the child. They step *around* everyone else. A player
+   character is only ever in mortal danger by choice — which is exactly as it should
+   be, because they will choose it.
+2. **The palace fights back.** Raunu's two silent years fire tonight: crystal barriers
+   sealing corridors, light flooding stairwells, wards flaring over huddled guests.
+   Use the palace's defenses as pacing valves — sealing a killer out of a scene,
+   sealing players into one — and let anyone who studied the wards (Agenda 5, the
+   gallery) *steer* them: reading a Boranis ward is Standard for them, Hard for
+   anyone else. Tables that found **the Root of the House** (Undercurrent A) hold
+   the master valve: from the Root, wards can be steered palace-wide, a dozen
+   guests can shelter behind the deepest crystal in Rekuzan — and the Uninvited
+   will not go down there — whatever the deep crystal is to them, they will not
+   cross its threshold. The module states this and does not explain it.
+3. **The clock still runs.** The leash pulls east. From the first scream, the
+   Uninvited have perhaps half an hour of story-time. They feel it; late in the
+   attack they get faster, sloppier, more terrible and more *human*. The last bell
+   of Oraga (ring it when the table needs the end) takes them, finished or not.
+
+## Movement VI — The Unmasking
+
+Midnight. Bells. The east doors open and Raunu Boranis mounts the dais to lead the
+Unmasking, as every host of every Oraga has, and the rite begins: the lamps
+brighten, the masks come off in a wave of laughter and candle-relight — and across
+the Crystal Court, three gray masks stay on.
+
+He speaks the rite's fixed words steadily — ritual suits him far better than small
+talk — and then sets down the cup, and the room, which has waited all night for
+this, goes silent enough to hear the candles. Deliver it word-for-word, and stop
+exactly where the text stops:
+
+> "The masks are down. The spirits are thanked. The year turns.
+>
+> And before it does — I told you I had something to say. Two years in the
+> keeping.
+>
+> *(he looks, once, toward the east wing — the only soft thing anyone has seen him
+> do all night)*
+>
+> House Boranis has been silent because—"
+
+**The instant the sentence breaks off, read — fast, and do not stop for questions:**
+
+> *The light goes out of the walls. Not blown out — drawn out, the rose draining
+> away from the crystal like water out of a cracked basin, from the far end of the
+> hall toward you. The music stops in pieces, instrument by instrument, as it
+> reaches them. Two hundred people take a breath at the same time.*
+>
+> *In the last of the light, three faces are still masked.*
+
+**He never gets to make the announcement.** That is the sentence the whole ball
+existed for, and it dies in the dark with everything else. Run the opening in
+fixed order, fast:
+
+1. **The lights die.** Mid-word. Not blown out — *drunk.* Every crystal in the
+   Crystal Court dims at once, as if the walls forgot sunlight. (The Uninvited's
+   presence unravels stored spellwork. Any player character holding a charged
+   Orthaen crystal feels it go cold and quiet in their hand — see sidebar.)
+2. **Raunu understands first.** In the dark, before the first scream — players
+   watching the dais (Agenda 2) catch it against the last candle-light — he does
+   not startle, does not finish the sentence, does not waste one second on
+   disbelief. His hand is already at his wrist. The east wing corridor booms shut
+   somewhere above, sealed from afar, and his voice — flat, carrying, instantly
+   obeyed — says the only farewell the ballroom gets: *"Corval. The stairs."*
+3. **The Wept moves.** The tallest of the three crosses the dark hall toward the
+   dais — not running, *arriving* — and the screaming starts.
+4. **The doors are wrong.** The Hollow is at the main doors, and the crowd that
+   surges at them breaks around it like water. The Radiant is nowhere to be seen —
+   it has gone for the east wing, and the first sign is the guards' lanterns going
+   dark along the gallery, one by one, like a fuse burning.
+
+Then release the beats. From here the module cannot script — it can only tell you
+where everything is and what everything wants. The night-tracker's crisis panel
+(Chapter IX) holds the map: **the Wept → Raunu. The Radiant → Veier. The Hollow →
+the doors, herding, keeping the herd from mattering.** Master Vell is already moving
+along the service passages toward the east wing, and the fastest route to the river
+gate runs through the garden stair.
+
+> **Sidebar — Crystals gutter:** Within a stone's throw of an Uninvited, a
+> triggered crystal charge works only on a Luck roll (Standard) — on a 6− the light
+> simply goes out of it. The palace's great wards are older and deeper and hold
+> longer, but even they gutter when one of the three stands close. This is worth
+> foreshadowing the exact moment a player's clever crystal plan meets it.
+
+### The default beats
+
+What history records, told in scenes. Bend everything except what the players bend:
+
+- **The dais.** The nine honor guards die or fall protecting their chief —
+  quickly, around the edges of the frame. Raunu does not run. He works: snapping
+  ward after ward alight between the Wept and the fleeing crowd, spending his
+  house's stored centuries like coin — the recluse nobody saw all night suddenly
+  commanding the whole burning room, and magnificent at it. Any player at his
+  side becomes his hands — *"the third sconce — turn it — NOW"* — and buys the room
+  minutes. Then the Wept is through the last barrier, and Raunu Boranis, who has
+  visibly been holding one crystal back — a second small thing, worn at his wrist,
+  twin to the one already spent sealing the corridor — looks at it, looks once
+  more toward the east wing, and *crushes it in his fist* instead of shielding
+  himself with it. What that charge does: every door between Veier's rooms and the
+  river seals itself behind her, one by one, all the way down. What the Wept does
+  then is quick.
+  *(If a player character is about to die shielding Raunu, the Wept takes them out
+  of the fight instead of out of the world — a Tier 2 Condition and a broken wall.
+  It has no orders about them, and no appetite either.)*
+- **The east wing.** The Radiant hunts Veier through corridors that lock themselves
+  behind her (Raunu's last gift, working), but it is faster than doors. What it is
+  not faster than: witnesses. Its Fracture (below) is that it *performs*; alone with
+  prey it is lethal, but under watching eyes it slows, poses, savors. Every player
+  character who chases it, harries it, or simply stands where it must be *seen* is
+  buying Veier hallway after hallway. This is where the whole design points: the
+  escape in the history books happens because people got in the way. Let it be
+  the players.
+- **The gardens — the Crossing.** Veier's flight meets its hunter in the open, and
+  the night's two hidden powers finally collide. Run it as its own set-piece; see
+  *The Crossing — Vell and the Radiant*, Chapter V.
+- **The hall.** The Hollow holds the doors until the Wept's work is done — then both
+  turn east. The bell rings, near or far, and all three of the Uninvited simply
+  *leave*: through windows, through walls of smoke, moving like things called home.
+  They do not look back. One of them — the Wept, if any player earned it — looks
+  back.
+- **The looters.** Not everyone in the palace is running *from* something. The
+  moment the screaming starts, Tavva's crew (Chapters IV and VII; `enemies/tavva.fof`, `enemies/gallery_knife.fof`) goes to work — the gallery's wards are guttering, its guards are
+  dying on the dais, and a season of planning meets the best cover Rekuzan will
+  ever offer. Two of her knives hit the trophy gallery (B7); the others work the
+  smoke-filled galleries and corridors, cutting purses, rings, and masks from
+  the fallen and the fleeing. **This is the night's one fully winnable fight,
+  and it is aimed straight at the players' better natures**: guests being robbed
+  as they crawl from the fire is a sight no decent character walks past, and no
+  Fracture, leash, or ward-lore is needed — just a blade, a posture, and the
+  willingness. The crew fights to escape, not to kill, breaks off the moment the
+  price turns real, and any of them caught and held is worth more than the
+  goods: by dawn, a captured looter is the inquest's favorite scapegoat and the
+  players' proof of what they saw. If nobody interferes, the crew gets away
+  clean — and the module notes, without comment, which kind of night the table
+  chose to have.
+
+### The Crossing — Vell and the Radiant
+
+Veier — wounded across the ribs by the Radiant's one clean pass in the east wing,
+upright anyway, moving with Thenya bluntness toward the water — meets Master Vell
+at the garden stair as if by appointment. Any player character with her (Agenda 4
+above all) is welcome company: Vell does not explain, does not slow, and does not
+refuse help. Then the lanterns die along the terrace behind them, and the Radiant
+steps out of the smoke — and for the first and only time all night, the pale
+factor stops being unmemorable.
+
+This is the crescendo, and its rule is simple: the players are caught between two
+people the mortal world has no answer for, and they cannot beat either one. What
+they can do is everything else, and everything else is what decides it. Run it in
+three beats down the garden's three levels:
+
+1. **The terrace.** Vell turns to face the Radiant, and moves — *the way the
+   Uninvited move*, arriving instead of running, distance negotiating with him —
+   and any player who has watched the three all night understands, wordlessly,
+   that whatever they are, he is the same order of thing, and more of it. The
+   wrapped sword stays on his back. It stays there through everything that
+   follows, and the module trusts the table to notice. The two meet without
+   preamble. The collision
+   is not fencing — it is pressure and shear, crystal lanterns bursting in a line,
+   the terrace balustrade exploding into gravel, forces the module deliberately
+   does not name. The Radiant recognizes him. It says one word — wary for the
+   first time tonight, and underneath the wariness, something older and uglier,
+   the special hatred the devout reserve for an apostate: *"...You."*
+2. **The lower garden.** The duel comes down the stairs *through* the party's
+   position — this is the crossfire, and every beat a nearby player character
+   faces it (see sidebar). Vell is holding the Radiant, barely; he cannot both
+   fight it and move Veier, and he says so, once, without turning: *"Take her.
+   The gate. Don't stop."* The players carry history in their arms down a garden
+   being demolished behind them. The Radiant, meanwhile, is losing the thing it
+   cannot bear to lose: its audience, gone running into the dark with the prize.
+   This is where its Fracture (below) is at its most invocable — dark, empty
+   terraces, nobody watching but the enemy it fears.
+3. **The river gate.** Unlocked — someone saw to it. A boat. Veier aboard. If the
+   Radiant breaks past Vell — and it does, exactly once, unless guilt is already
+   dragging at it — it reaches the water's edge as the boat pulls
+   out: one clean line of attack, one last chance, and **whatever stands at the
+   gate is what it has to go through.** A held gate, a doused lantern, a body in
+   the way, a Fracture finally invoked — any of it is enough; the module asks only
+   that the margin be *the players*, not luck. Then the bell. The Radiant stops as
+   if hooked through the spine, stands one heartbeat in the shallows watching the
+   boat — and is gone east with the mist coming off the water. The last any of
+   them see: a pale man rowing hard into the dark, a woman bent over her own
+   heartbeat, and the palace burning rose-colored behind them.
+
+If the Wept finished on the dais, it arrives at the water's edge for the end of
+beat 3 — and does not pursue. It stands where the river laps the gate, carved
+tears catching the fire-light, and watches the boat go. If any player character
+earned its Fracture, this is where it looks at them. Then east.
+
+> **Sidebar — Caught in the crossfire:** while the Crossing runs, any player
+> character in the duel's path faces one consequence per beat — flying crystal,
+> collapsing stonework, a shear of force that was aimed at no one. Call for a
+> reaction (Dexterity or whatever the fiction offers, Standard): on a 10+ they
+> ride it; on a 7–9 they take a Tier 1 Condition or lose their next action
+> shielding someone; on a 6− a Tier 2 Condition or the ground between them and
+> the gate gets worse. Never aim the duel *at* a player character — the terror
+> of the Crossing is precisely that neither combatant cares that they are there.
+
+### You Cannot Beat Them
+
+Say it plainly at the table when the fiction earns it: **the Uninvited cannot be
+defeated by force tonight — not by the players, not by fifty guards, not by the
+palace.** Weapons land and matter less than they should. A stat block reaching
+Resolve 0 does not mean a kill: it means the killer *stops indulging the
+interference* — puts the attacker through a wall (Tier 2 Condition, out of
+this scene), stops toying, and walks on toward the task, Resolve track reset. Fighting the Uninvited never ends in victory. It buys time with bodies,
+and time is real currency tonight: every exchange spent on a stubborn defender is
+a hallway Veier gains, a dozen guests out the service doors, a ward resealed.
+Make the cost honest and the purchase visible, and a hopeless fight becomes the
+best scene at the table.
+
+What actually changes outcomes, in ascending order: the palace's ward-fire
+(slows and channels them), the leash-clock (ends them), and the Fractures
+(reaches the person inside each of them). That is the complete list.
+
+### The Fractures
+
+The Uninvited are beyond any table of starting characters, and the module does
+not pretend otherwise — force buys time, never victory. The point is the seams.
+Each of the three is still a person — that is the terrible engine of them — and a
+player character who has *paid attention* can reach the person.
+
+**How ammunition works.** Each Uninvited has **tells**: human moments that slip
+out through the mask, salted through Movements III–V at the places listed below.
+A tell isn't hidden behind a roll — a player character in the right place sees
+it; Undercurrent D is the thread for hunting them deliberately, but plenty land
+on players who are simply *at the ball*. Witnessing (or hearing secondhand, from
+Sella, Kovaun, or another player) **one tell** unlocks that Fracture at **Hard**;
+**two or more** drop it to **Standard**. During the attack itself, everything the
+Uninvited do openly (below) counts as tells too — a table that arrives at
+midnight with nothing can still earn a Fracture in the fire.
+
+Invoking a Fracture is a Soul-facet action (usually Persuade, Perform, or Attune;
+sometimes just a bared truth). On a 10+, the effect lands in full; on a 7–9 it
+lands and the Uninvited answers with one terrible parting blow or word. Each
+Fracture works once.
+
+**Table V–1: Fracture Tells**
+
+| Who | Tells before midnight *(where / when)* | Tells during the attack |
+|---|---|---|
+| The Wept | Watches the young pages at the feast a beat too long (B3, Mv III–IV) · leaves a mourner's offering in Elanna's niche, in a rite centuries out of date — Mother Sella can say exactly *how* out of date (B6, Mv IV) · lingers at the east wing doors humming a cradle-song no one living knows (Mv V) · the Dead Dance: *"You dance like my daughter would have"* (Mv V omen) | Goes still at the sound of a child crying somewhere in the palace · under the carved tears, the mask is a woman's face |
+| The Radiant | Makes an antique sign of blessing over the food — Prelate Kovaun recognizes the form; it has not been used in living memory (B3, Mv IV) · lights up when conversation turns to duty or service; asks a guest, warmly, *"Whom do you serve?"* (any social scene) · joins the Dead Dance and cannot resist dancing beautifully, where the light falls (Mv V) | Kills are staged — offered upward, like rites · visibly slows and poses when watched |
+| The Hollow | Stands always beside a different exit (any Movement) · answers small talk with devastating flatness — asked if he is enjoying the festival: *"It ends the same whether I do."* (any social scene) · watches the servants who belong to each other — Anha and her kitchen family — with something like hunger (B10 edges, Mv II–V) | Holds but never advances · flinches from ward-fire the way a tired man flinches from being asked to try |
+
+- **The Wept** *(sorrow)*. Truth: she was a mother once, and disease took her
+  family while she stood by helpless — and tonight she has been sent to do to a
+  family, with her own hands, what the world once did to hers. Invoked: she stops.
+  Mid-motion, mid-kill. For one full beat she is a woman standing in a burning
+  ballroom — long enough to pull a victim clear, seal a ward, finish an escape.
+  *(A table that finds this before Raunu dies has earned the ⟨If History Breaks⟩
+  sidebar below.)*
+- **The Radiant** *(devotion)*. Truth: he believes, and has believed for a very
+  long time, that revelations were spoken to him and that this errand is holy —
+  his kills are not showmanship but **liturgy**, service that must be witnessed
+  to count as worship. Understand exactly what his Fracture can and cannot do:
+  **the Radiant cannot be turned.** Not from the hunt, not from the errand, not
+  by darkness or doubt — nothing short of the leash ends his night. What he can
+  be made to do is *feel*. Two roads to the guilt: **deny the congregation** —
+  douse the lights, empty the room, turn every back, or a Perform action that
+  makes a player character the better spectacle; unwitnessed, his service stops
+  counting as worship, and the liturgy collapses into plain ugly work that even
+  he can feel the shame of — he hurries, stops savoring, does it *badly*. Or
+  **plant the doubt** — a priest, a believer, or anyone armed with his tells,
+  declaring the truth to his face: *no god worth the name asks for a stolen
+  child. Whatever spoke to you, it was not the Just One.* On a hit the words
+  lodge. He does not stop, does not answer, does not turn — but guilt gets into
+  the errand like grit into a joint: he falters at thresholds, looks back,
+  re-stages kills that were already staged. Guilt is slow, and slow is
+  hallways — the module expects the margin at the river gate to be made of
+  exactly this.
+- **The Hollow** *(despair)*. Truth: he was promised family once — belonging,
+  after a life of nothing — and what he got instead was the leash. He has not
+  wanted anything since. He holds the doors because holding is easier than
+  wanting. Invoked: not ferocity — you cannot frighten a man who would not much
+  mind ending — but **sincerity**. See him. Name the emptiness truly. Offer one
+  honest moment of the thing he was promised, or simply tell him, one person to
+  another, that he can stop. He stops. He opens his hands, the doors open, and
+  he leaves the field early — the only one of the three who goes home before he
+  is called. Two hundred people stop being hostages.
+
+## Movement VII — The Longest Night
+
+The Uninvited are gone. The palace is fire, smoke, ward-light, and screaming — and
+for one long hour before the sect guards fight their way in, the player characters
+are the only order in it. This Movement is where the module keeps its tone promise:
+**people are brave.** Guests shield strangers. Corval, bleeding, counts his staff
+like a man counting his own fingers. Anha knows the other way out, and if Agenda 8
+is in play, she and her sibling empty the smoke-filled galleries through the service
+passages. Give every player character a scene of what they are best at, and give
+the room to whoever earned it least an hour ago — Vorlain, say, hauling guests out
+of the burning banquet gallery, to everyone's permanent confusion including his own.
+
+Word arrives with the guards: **there were other attacks tonight.** Fires in two
+sect districts; a Blackwatch courier post found dark. Nothing so terrible as this —
+but enough that every house's blades were pulled two ways at midnight. *(That is
+all the module knows about the other attacks. Diversions, of course. By whom is the
+same answer as everything else tonight.)*
+
+And then the counting: Raunu Boranis is dead. Veier Nolonaire is gone. Whatever
+each player character saw, they are now the most important witnesses in Val'loh —
+which by morning will make them assets, threats, or scapegoats to every faction in
+the city. If the night ends here as a one-shot, end on the epilogue below. If the
+campaign continues, Chapter VI's aftermath wing begins at dawn.
+
+### Epilogue (one-shot ending)
+
+Read or paraphrase, adjusting for what the table did:
+
+> The fires are out by dawn. The story is already wrong by noon — three stories, in
+> fact, one for each faction that needs it, and none of them yours. No one is ever
+> charged. In the years to come, "Oraga Night" will mean this night: the chief who
+> knew everything, dead in his shining hall, mid-sentence; his bride gone into the
+> river dark; three gray masks that no one ever invited; and a something-to-say,
+> two years in the keeping, that no one will ever hear. The mists off the
+> eastern coast, the fishermen say, are rising again.
+>
+> You know what you saw. You are nearly the only ones who do. And on quiet nights,
+> from time to time, each of you dreams of dancing — a warm hand in yours, and a
+> voice, kind and centuries out of fashion, saying: *you dance like my daughter
+> would have.*
+
+Then go around the table once: **what does your character carry out of Oraga
+Night?** An object, a debt, a truth, a name. Write the answers down. If you ever
+play in Val'loh again, they are canon at your table.
+
+---
+
+## ⟨If History Breaks⟩
+
+The recorded outcome is the default, not a cage. When the table genuinely diverges,
+these sidebars keep the night standing. All divergences share one rule: **be
+generous.** A table that beats history has done something remarkable; never claw
+it back.
+
+**⟨They save Raunu.⟩** Possible — it takes the Wept's Fracture found early, plus
+real sacrifice at the dais. If they do it: Raunu survives his own assassination,
+which makes him the most dangerous man alive and the players his only trusted
+witnesses. Veier and the child still must vanish — Raunu himself, once he
+understands what came for his son, will insist; grieving the living is the price of
+this victory. Vorlain's face when his brother walks out of the smoke is worth the
+whole divergence. Your Val'loh now runs on: a living Raunu hunting an eastern power
+with a party of proven allies is a campaign, and a very good one. *(In the wider
+canon of Svara he dies tonight; your table's canon is now its own, and the module
+blesses it without reservation.)*
+
+**⟨The child is taken.⟩** The darkest branch: the Radiant reaches the river first.
+The module refuses to leave it there, and so should you — the leash east is long,
+the boat is slow, and Master Vell does not accept endings. The aftermath wing
+becomes a pursuit: down the river, along the coast, toward mists that are rising
+again — with Vell, suddenly and terrifyingly forthcoming, as patron. The child is
+recoverable at the water's edge; past the mist-line, the module draws its curtain
+and your campaign begins.
+
+**⟨They trap one of the Uninvited.⟩** Killing one is off the table — see "You
+Cannot Beat Them" — and the module holds that line even against brilliance. But
+*trapping* one, briefly, is the outer edge of the possible: deep Boranis
+ward-crystal is the one thing tonight that their wrongness does not simply
+unravel, and a table that lures one into the Root's threshold, a resealed ward-
+corridor, or a gallery ring of Raunu's own work has caught something no one has
+ever caught. It answers no question about its master or its task. It will, once,
+in the quiet before the last bell — to the player who treats it as a person and
+not a prize — answer a question about *itself*. If its mask comes off in that
+hour: a face. A person's face — ordinary, and tired in a way no living face is
+tired, and at the very end, unmistakably relieved to have been *seen*. Then the last bell takes
+it anyway — the leash tears it out through ward, wall, and witness alike, and by
+morning there is nothing to show the inquest but damage. The public record holds:
+no bodies, no names, no charges.
+
+**⟨They expose the truth.⟩** Suppose the players stand in the ashes with real
+evidence — the study's crystal reliefs, a Fracture's confession, the mask of a dead
+Uninvited. They discover the coldest fact of the aftermath: *nobody powerful wants it.*
+Draunel wants Vorlain implicated; the Circle wants a trade rival implicated; the
+Church wants the file closed and the mists unmentioned; Vorlain wants anything
+that is not himself. The truth without a patron is not power — it is exposure, and
+it makes the players the most interesting people in Rekuzan to several
+organizations at once. That is not a dead end. It is a campaign frame, and the
+aftermath wing leans into it.
+
+**⟨A player character dies.⟩** Let it mean something and cost the enemy tempo —
+a death that holds a corridor or a gate is written into the night forever. Then,
+between beats, hand the player Corval, Anha, Maiven, or Vorlain to finish the
+night with. Nobody sits out the Longest Night.

--- a/adventures/oraga_night/06_Wings.md
+++ b/adventures/oraga_night/06_Wings.md
@@ -1,0 +1,149 @@
+# VI. The Wings — Prelude and Aftermath
+
+*Optional chapters that turn the one-shot into a 3–4 session short campaign. The
+prelude runs before Chapter IV; the aftermath runs after Chapter V. Both are written
+loose — frames and scenes, not scripts — because their job is to give the table more
+Rekuzan, not more rails.*
+
+---
+
+## The Prelude Wing — Nights One and Two of Oraga
+
+### Night One — The City of Lanterns
+
+Rekuzan at festival: the old crystal walls lit rose, the trade district a river of
+lanterns, every tavern roaring, every tribe's traders in town at once. Use Night One
+for three things: arrivals, invitations, and appetites.
+
+**Getting in.** Characters who don't yet hold an invitation earn one tonight. Scenes
+to offer:
+
+- **The burned list.** Lord Essar Draunel's aunt burned hers publicly at a supper —
+  and her footman fished the charred card from the grate and knows a buyer when he
+  sees one. Price negotiable; discretion not included.
+- **The patron's table.** Any of the four patron factions (Circle, Church, Draunel,
+  Thenya) recruits tonight — a private room, a fee, an agenda card, and the pointed
+  observation that the patron's own name must never come up.
+- **The servants' door.** House Boranis is hiring festival staff through a harried
+  under-steward at the Gatehouse Court. The interview is thirty seconds long. The
+  background check is shorter.
+- **The mask-maker.** Every guest needs a spirit-mask, and the finest maker in the
+  city is **Otta Vesh**, whose workshop is booked beyond reason. Getting fitted at
+  Vesh's is a social gauntlet worth playing: half the named cast passes through it
+  tonight, unmasked and off guard — the best soft-introduction scene the module has.
+  *(Plant here: Vesh keeps a casting-blank of every face she has ever fitted — a
+  wall of them, her rite and her pride — and she remembers every mask that ever
+  left her hands. At the ball, a sharp-eyed character may notice the three gray
+  masks match no maker's style in the city — and if they ask Vesh afterward: no
+  one made them. No one would know how. The material is wrong.)*
+
+**Appetites.** Seed each player character one desire that only Rekuzan at festival
+can offer — a rival to shame, a debt to outrun, a person to find. The prelude works
+when the ball is not the players' first want but their second.
+
+### Night Two — The Lantern Course
+
+The festival's middle night: games, races, and the **Lantern Course** — a rooftop-
+and-riverbank race through the trade district that any character may enter (a chain
+of Body-facet rolls, glory and side-bets attached). Meanwhile the city tightens
+around tomorrow's ball, and the undercurrents surface:
+
+- **Rumor harvest.** Every social scene tonight yields a roll on the rumor table
+  (Chapter IX). By midnight the table should hold five or six contradictory Raunus.
+- **The Blackwatch rider.** In a dockside tavern, a courier of the eastern watch
+  drinks with the discipline of a man off duty for the first time in a year and says
+  more than he should: *"Mist's never been so low. You can see the old drowned
+  stones off the point. The old men won't look at the water. Say the sea's holding
+  its breath."* He will not say more; he was not told more. *(This is the campaign's
+  one direct touch of the east before midnight. Let it land and move on.)*
+- **Sect blades in the streets.** Guard patrols double. A quiet word says every
+  great house has hired extra swords for tomorrow — nobody trusts a Boranis party.
+  Characters may notice the opposite fact: House Boranis itself has hired none.
+- **Vell.** Characters who earned Agenda 6 meet their stranger tonight — a tall,
+  pale factor with old coin and no small talk. Characters who didn't may still
+  glimpse him: buying rope and lamp-oil, walking the river wall below the Boranis
+  gardens at dawn, unremarkable to everyone but the one player who rolls well.
+
+End Night Two with the invitations checked, the masks fitted, and the palace gates
+opening at dusk. *Go to Chapter IV.*
+
+---
+
+## The Aftermath Wing — The Morning After
+
+Dawn, ash, and arithmetic. The aftermath is an investigation the module already
+knows the end of — **no one is ever charged** — but the players don't know that,
+and the road to the dead file is where this wing lives. Run it as pressure from
+four directions on the only good witnesses in the city.
+
+**The inquest.** The sect guard seals the palace with the guests inside it until
+midday and takes testimony. The inquest is jointly run — a Draunel captain, a
+Church notary, a Circle observer — which means it is three inquests wearing one
+coat, each fishing for the version that serves its master. And the Church notary
+holds the only pen in the room — by law, the only pen in the *city* — so player
+testimony is heard, taken down, and *edited in real time*; players sharp enough to
+demand their statement read back will find it subtly improved. What gets written
+tonight is what happened, forever, and everyone at that table knows it. What each faction wants pinned
+where: **Draunel** wants Vorlain guilty; **the Circle** wants a foreign trade rival
+(the Phern guests spend an ugly morning under suspicion); **the Church** wants the
+file closed, the mists unmentioned, and every witness who says "the crystal lights
+died by themselves" gently reclassified as hysterical; **Vorlain** wants a
+culprit — any culprit — convicted fast, because until one is, the only man who
+profited is him.
+
+**What never gets out.** The pregnancy stays secret. Forever. The midwife is
+simply *gone* by dawn — hired discreetly, paid in old coin, never found, one more
+piece of the night erased by someone with centuries of practice — and the skeleton
+staff hold the silence they were paid for, because the alternative is explaining
+what they half-know to an inquest hunting scapegoats. The record the world gets is
+a vanished *bride*, never a vanished *heir*: history never learns what the ball
+was for, what the recluse was about to say, or why anyone would want the lady of
+the house at all. Which means players who reached the east wing (Undercurrent C,
+Agenda 4) now hold a truth that exists nowhere else in the world — priceless,
+unprovable, and dangerous in exact proportion to who they tell. Vorlain would pay
+a fortune for it and might even believe it. The Church would make it, and them,
+disappear into a closed file. The Thenya would go to war over it. Choose carefully
+is not advice the module needs to write down; the players will feel it.
+
+**Vorlain's morning.** He is chief now in everything but ceremony, and he is
+*afraid* — visibly, to anyone who knows what fear looks like on a clever face. He
+knows he didn't do it. He knows no one will believe that forever. And he knows,
+better than anyone alive, that his brother did not lose. Vorlain makes a blunt,
+startling offer to competent-looking player characters: find out what actually
+happened, on his coin, reporting only to him. He is, the module notes with a
+straight face, the only patron in Rekuzan who genuinely wants the truth.
+
+**The trail.** For tables that chase it, the physical evidence runs out in this
+order, each step a good scene: the river gate (unlocked, oiled, recently used); a
+boat missing from a fisher's mooring downstream (paid for in old coin, three times
+its worth, left neatly); a night-carter on the west road who carried "a factor and
+his sick daughter" as far as the crossroads and remembers the man's cold hands; and
+then nothing. The trail does not merely go cold — it goes *tidy*, erased by someone
+with centuries of practice. The players should end certain of exactly two things:
+the lady left the palace alive, and whoever took her wanted her safe. (Only players
+who learned the east wing's secret know to count a third passenger.)
+
+**The counting of the house.** Threads to pay off from the ball: Corval, ruined and
+dignified, executing the testament Raunu swore aloud in the chapel — three days
+before the ball, Corval and Mother Sella standing witness — providing for every
+servant by name. Anha and the skeleton staff, finally free to talk, with two
+years of eerie domestic detail and no answers. The nursery, untouched by fire, that
+inquest officers keep finding reasons not to stand in. Maiven Nolonaire, refusing
+to leave the city without her cousin or a body, becoming the players' fiercest
+ally if they earned her trust — the Thenya do not abandon their own.
+
+**Where it ends.** Give the wing two sessions at most, then close the file the way
+history does: the inquest names "agents unknown, likely Mazaaian," which everyone
+knows is false and everyone signs. Then put the choice in front of the players that
+the whole module has been building: *you know more than the record. What do you do
+with it?* Their answer — sell it, bury it, swear it to Vorlain, sew it into a Scora
+sleeve, or carry it east toward the rising mists — is the campaign's next act, and
+it is theirs, not the module's.
+
+> **Sidebar — Going east:** Sooner or later, a good table looks at the mists. The
+> module ends at the mist-line on purpose: what waits past the Blackwatch belongs
+> to the deep future of this setting. If your table sails anyway — of course they
+> do — you are off the map with the module's blessing and one true bearing: the
+> mists are rising again *because the child got away*, and nothing that lives out
+> there knows where he went. A campaign that keeps him safe without ever meeting
+> him is a campaign worthy of this night.

--- a/adventures/oraga_night/07_Cast_of_the_Ball.md
+++ b/adventures/oraga_night/07_Cast_of_the_Ball.md
@@ -1,0 +1,337 @@
+# VII. Cast of the Ball
+
+*Fifteen named guests. Each entry: who they are, what they want, what they fear,
+their secret, and how to play them. NPCs never roll dice — their entries note the
+difficulties they impose instead. The night-tracker (Chapter IX) maps where each
+stands in every Movement.*
+
+---
+
+## The House
+
+### Raunu Boranis — the Host
+*Chief of the Orthaen. Seen exactly four times tonight, and the fourth is midnight.*
+
+**Wants:** one uninterrupted sentence, at midnight, two years in the making. He
+does not get it. **Fears:** something is coming for his family; he does not know
+what, or when. His whole silent palace is the shape of that suspicion. **Secret:**
+all of them — see Undercurrents A and B, and the Root.
+
+**His four appearances** (he is otherwise absent, and his absence is the ball's
+weather): a still figure on the high gallery in Movement III, gone when looked
+for; the summonses in the empty Audience Hall (Movement III); the awkward toast
+and the two plates (Movement IV); and the Unmasking rite at midnight. That is the
+entire public Raunu. The guests came to see a recluse and are seeing one.
+
+**Play him (the summons):** awkward, unhurried, unmistakably out of practice —
+long pauses, no pleasantries, the true thing said where the polite thing was
+expected, and no apparent awareness that this is strange. He listens *completely*,
+which unnerves people more than the silence. He knows things about each summoned
+guest he has no business knowing (pick from the player's own backstory; one detail
+per summons, delivered almost absently), because a man who leaves no eventuality
+unprepared for did not neglect to learn his guests. He never threatens; a
+reputation for total preparedness means never having to. Each summons ends
+abruptly, on something that is nearly a kindness. Deceiving Raunu is **Very
+Hard**. Impressing him is easier than anyone expects: tell him a true thing he
+did not already know.
+
+**At the Unmasking:** see Chapter V. Custom compels his return to the dais — the
+one predictable moment of his night, which is exactly why it is the moment. He
+never gets to make the announcement. He understands first, spends everything on
+the escape, and dies a host: the recluse nobody saw all evening ends it
+commanding a burning room, putting his body and his house between his guests and
+the Wept.
+
+### Veier Nolonaire — the Bride
+*Of the Thenya; one of five gifted Thenya alive, though almost no one knows it. Two
+years unseen — and she is not seen tonight either. She never enters the ball.*
+
+**Wants:** her child born safe; her cousins to know she chose this. **Fears:** the
+same thing her husband fears, learned from watching him prepare. **Secret:** she is
+happy, genuinely and unfashionably, and rumor has no shelf for it.
+
+**Where she is:** the east wing (B9), all night, near her time, the midwife in
+attendance. She is reachable only by players who earn the east wing — Agenda 4's
+errand, Anha's passages, Undercurrent C — so a scene with her is a prize, not a
+schedule item. Players who reach her after the toast find her at dinner with
+Raunu, the two plates explained at last — the only place all night anyone sees
+Raunu Boranis at ease.
+
+**Play her:** blunt to the point of comedy, funny in a dry border-country way,
+homesick and unashamed of it. She answers the delegation's careful diplomacy
+(Agenda 4) with take-it-or-leave-it directness: *"I am well. I am watched over. Tell
+my uncle his message took two years to reach me, so his worry can wait two more."* She reads
+people nearly as well as Raunu and is far less polite about showing it. Guests who
+reach her expecting a prisoner or a madwoman get a brisk education.
+
+**At the Unmasking:** in the east wing when the lights die, the corridors sealing
+themselves behind her — her husband's two crystals working. Wounded once, cleanly,
+by the Radiant; upright anyway; down the private stair and out through the gardens
+on Vell's arm (the Crossing, Chapter V). If her gift matters at your table — a
+bonded loved one in mortal peril — it flares exactly once, without training or
+explanation, and the module suggests spending it on a player character who bled
+for her.
+
+### Vorlain Boranis — the Brother
+*Ruled for the missing year; killed two cousins doing it; gave it back without a word.*
+
+**Wants:** the seat, forever, aching, and — this is the part House Draunel cannot
+imagine — *not like this*. **Fears:** Raunu. Comprehensively. Fear of his brother is
+the load-bearing wall of his personality. **Secret:** he has no plot tonight. He came
+because not coming was more dangerous.
+
+**Play him:** silk over springs. Charming, funny at others' expense, collects
+weakness reflexively the way other men pocket coins. With Agenda 3's overtures he is
+delighted, encouraging, and says *nothing* — sober. Drunk (it takes real work, and
+Essin will try to stop it), he says one true thing: *"You think I want him dead. I
+want him to LOOK at me the way he looks at his ministers. Gods help whoever actually
+touches him — I've seen what he does to surprises."* **At the Unmasking:** he is the
+night's strangest hero — hauling guests from the burning banquet gallery (B3), to
+everyone's permanent confusion including his own — and by dawn, the prime suspect.
+Both facts are true, and the aftermath wing runs on them.
+
+### Minister Corval — the Majordomo
+*The last of the old household's officers; runs the whole ball with two dozen staff.*
+
+**Wants:** the night to go perfectly, because it is the house's face and his life's
+work. **Fears:** that he no longer knows the house he serves. **Secret:** he knows
+the shape of everything — the staff cuts, the sealed wing, the midwife, the master's
+locked study, the testament he stood witness to in the chapel three days ago — and
+the meaning of none of it.
+Loyalty has kept him from assembling the pieces. He is the faithful servant's
+tragedy, one honest conversation away from understanding.
+
+**Play him:** thin, upright, old, magnificent under pressure, doing the work of six
+chamberlains. Bribing Corval is impossible — not Hard, *impossible*, tell the
+players so. Helping him — genuinely, with the wine crisis or the escalating seating
+feud — earns more than gold buys: gratitude, gossip, and doors. Deceiving him about
+household matters is **Hard**; about anything else he is too tired to check.
+
+### Anha — the Under-Cook
+*Agenda 8's sister. Four years in the kitchens; two years in the silence.*
+
+**Wants:** to keep her head down and her triple wages flowing home. **Fears:**
+naming the wrongness out loud, in case naming is what makes it real. **Secret:** two
+years of eerie domestic detail — east wing lights burning all night, meals for two
+sent up and meals for *three* coming back down these last months, the master's voice
+in empty rooms, corridors she is forbidden to sweep — and no frame to put around any
+of it.
+
+**Play her:** quick, practical, frightened in a low-grade chronic way she has
+stopped noticing. She talks to family or kindness, not to pressure. Everything she
+knows is true and none of it is the answer, which makes her the best rumor engine
+in the palace: she deals only in facts. **At the Unmasking:** she knows the service
+passages, and becomes one of the night's quiet heroes if any player thought to
+befriend her.
+
+---
+
+## The Factions
+
+### Prelate Damaris Kovaun — the Church's Eye
+**Wants:** to file Raunu Boranis under something. Anything. **Fears:** the mists —
+which is to say, the one memo from the east that reached her desk and was above her
+seal to read. **Secret:** the Church's interest tonight is not doctrinal; her
+superiors want to know whether the man who returned is *the man who returned*, and
+she has not been told why the question is phrased that way.
+
+**Play her:** urbane, watchful, a career diplomat in vestments; works the room like
+a census-taker of souls. Runs Agenda 2 with scrupulous courtesy and pays her debts.
+Lying to Kovaun about matters of faith is **Hard**; she has heard everything.
+
+### Mother Sella — the Death-Sister
+*A lay sister of Elanna, invited by name, in Raunu's hand, to everyone's surprise.*
+
+**Wants:** to tend the Oraga rite properly: the masks, the year's dead, the sending-
+home. **Fears:** nothing; she is an Elanna follower of the old northern school, and
+acceptance is the whole doctrine. **Secret:** Raunu asked her, at the wedding two
+years ago, what her order teaches about *dying well*, and she has wondered since why
+a man that age wanted the answer that badly. It is she who keeps the fresh offerings
+in Elanna's chapel niche.
+
+**Play her:** calm as deep water, kind without softness. The chapel (B6) is hers all
+night, and it is where shaken players wash up. If the night needs someone to say
+what it meant, that someone is Sella, and she gets one line at the epilogue: *"The
+dead were sent home tonight. All but three. Those, child, were somebody else's
+dead — sent out."*
+
+### Mistress Rhaza Callun — the Circle's Reckoning
+**Wants:** Raunu's next decree, before it lands on her margins. **Fears:** an heir —
+a *dynasty* of Raunus — which is why Movement IV turns her polite loathing into
+something with a horizon. **Secret:** the Circle has already gamed a Vorlain
+chieftaincy and priced it attractive; she is here tonight to check the arithmetic,
+not to act on it. (She would be horrified to be called a conspirator. She is merely
+*prepared* — the module notes the resemblance to her host without comment.)
+
+**Play her:** iron-grey, cordial, terrifyingly numerate. Runs Agenda 1 and pays on
+delivery. Deceiving her about money is **Very Hard**; about anything human,
+**Easy**.
+
+### Master Pellin Corro — the Phern Magnate
+**Wants:** a pleasant evening among people who finally treat Phern money as money.
+**Fears:** the thing his gift keeps ringing about, all night, pointing nowhere.
+**Secret:** none. Corro is that rarest ball guest, exactly what he appears — which
+is why his mounting, unexplained dread (the Movement II omen) is worth a dozen
+warnings from anyone else.
+
+**Play him:** small, merry, expansive — and increasingly, visibly *wrong* as the
+night goes on: losing sentences, glancing at doors, standing with his back to walls.
+A player who takes him seriously and walks the room with him is doing real
+detective work, at the right altitude. **At the Unmasking:** his gift finally
+finds its bearing — three seconds before the lights die, Corro is already moving,
+and following him saves lives.
+
+### Lord Essar Draunel — the Rival
+**Wants:** House Draunel one seat closer to the chieftaincy, tonight if possible,
+patiently if not. **Fears:** being seen wanting it. **Secret:** Agenda 3 is his, and
+he has three other irons in tonight's fire the module leaves to your invention — a
+Draunel never brings one plan to a Boranis party.
+
+**Play him:** the anti-Raunu — polished, obvious, ambitious in the standard
+noble key. Useful to the table as a patron, a foil, and by dawn (aftermath wing) the
+loudest voice insisting Vorlain hang for this.
+
+### Essin Boranis — the Cousin
+**Wants:** Vorlain sober, unrecorded, and unbaited — Essin is the keeper his cousin
+does not know he needs. **Fears:** House Draunel's patience. **Secret:** he served
+the year of Vorlain's rule as fixer, and knows exactly where its two bodies are
+buried; he has spent three years being pleasant to everyone in case it stops
+mattering quietly.
+
+**Play him:** affable, forgettable on purpose, always somehow between Vorlain and
+whoever is working him. The Agenda 3 player's true opponent, and a fine sparring
+partner: deceiving Essin is **Hard**, and he deceives back.
+
+### Maiven Nolonaire — the Cousin from the Border
+**Wants:** proof of Veier — alive, well, *unforced* — carried home in Thenya hands.
+**Fears:** that the pact was a purchase and her kinswoman the price. **Secret:** the
+delegation's diplomatic brief is thin cover; the Thenyan chief's actual instruction
+was *"if she is a prisoner, bring her out,"* and Maiven, border-raised and direct,
+intends to.
+
+**Play her:** Veier ten years younger and thirty degrees hotter-tempered. Runs
+Agenda 4. The toast (Movement IV) lands on her like a slap — *two years, two
+plates, a promised midnight pronouncement, and still no kinswoman* — and her
+formal request for an audience, declined by a miserable Corval, is the last
+diplomatic thing she does tonight. From there she is one bad hour from going over
+the east wing wall herself, which makes her the Agenda 4 player's natural ally or
+runaway problem. **At the Unmasking:** she goes *toward* the east wing,
+immediately, and dies there unless somebody competent goes with her. The module
+would prefer somebody competent went with her.
+
+---
+
+## The Other Guests
+
+### Master Vell — the Pale Factor
+*Tall, pale, soft-spoken; a trade factor no one remembers inviting — carrying,
+of all things, an enormous broadsword wrapped in white cloth across his back.
+See Chapter II: he is the second hidden power's whole presence at the ball.*
+
+**Wants:** the river gate open at midnight and no one ever remembering his face.
+**Fears:** nothing in this palace — but he treats the three gray masks with the
+respect of a man who knows exactly what they cost. **Secret:** all of them.
+
+**The sword:** in a culture where strong personalities wear big steel, a wrapped
+greatsword on a factor's back earns an eyeroll and nothing more — which is
+precisely why he can carry it. He never touches it. He never unwraps it. If a
+player asks about it, he says only, *"An inheritance,"* and means it. *(MM
+truth: unwrapped, the blade would release the screams of every soul it has
+taken — enough to drop most of a ballroom where they stand. He refuses to
+unwrap it. What it cost him to be given such a gift, the module does not say,
+and the white cloth stays on all night — including at the Crossing, where he
+fights the Radiant with it still bound. If players notice that — a man dueling
+something unbeatable while deliberately not using his weapon — let them notice.)*
+
+**Play him:** courteous, brief, and *finished* — every conversation with Vell ends
+when he decides, somehow without rudeness. He answers questions with smaller
+questions. He is immune to every lever: bribery, flattery, threat, Charisma — mark
+all social pressure on Vell **Very Hard**, and let even full successes buy honesty
+rather than compliance ("You are observant. Enjoy the ball."). Players who shadow
+him find only preparations: a walked garden, a tested gate, a purchased boat. All
+night he does not fight, does not hurry, and is never once interesting to look
+at — and that last is not luck. *(MM truth: his unmemorability is a gentle,
+constant pressure on the minds around him; he reads most guests as easily as
+faces, and can steer a weak mind outright. Corval's inability to hold the
+gray-mask question has a cousin: nobody can quite hold Vell either. A player
+with an exceptional will who studies him directly may feel it — a Very Hard
+Spirit roll to notice the nudge — and earns, on a success, the most dangerous
+piece of information at the ball: someone is editing you.)*
+
+**One line he does not cross, and one he does:** he will take the path that
+spills the least blood if one exists — and if none exists, he will be ruthless,
+because the one thing he will not do is fail. Players standing between him and
+the river gate at the wrong moment should understand, from his face alone, that
+the courteous factor has already done the arithmetic and they should move.
+
+Then the Crossing (Chapter V), and the pale factor is unveiled in the only
+language the night speaks: he moves *the way the Uninvited move* — arriving,
+not running — and he holds the Radiant, a killer the module has spent two
+chapters establishing as unbeatable, alone, barely, long enough. Any player who
+has watched the three all night understands without being told: whatever they
+are, he is the same order of thing, and more of it. The module never explains
+him. The Radiant's one word of hate — *"...You."* — is the entire exposition.
+
+**One crack in the ice, if a player earns it** (helps the escape without being
+asked, or shields Veier at real cost): at the river gate, Vell looks back — the
+only time all night — and gives them one sentence. Suggested: *"Twenty years from
+now, when you hear this night has finally mattered — that was you."* Then the
+water takes him.
+
+### The Uninvited — the Three Gray Masks
+*Stat files: `enemies/the_wept.fof`, `the_radiant.fof`, `the_hollow.fof`. Their
+truth is Chapter II; their Fractures and full tell-tables are Chapter V; their
+conduct before midnight is here.*
+
+They arrive with the Movement III crush, and until midnight they do nothing but
+attend the ball — and this is the thing to play correctly: **they are people, and
+good company.** They eat. They drink and praise the vintage. They converse with
+antique courtesy and dance in a style two centuries out of fashion, and a guest
+who spends ten minutes with one walks away charmed, having learned nothing and
+feeling obscurely that they were the one being kind. The wrongness is all at the
+edges: masks from no maker's hand, names on no one's memory, speech from another
+age — and near them, quietly, Orthaen crystals go faint. What makes them
+monstrous is not what was taken from them. It is how much is left.
+
+Their human moments — the Wept watching the young pages too long, her mourning
+rite in the chapel, the cradle-song at the east wing doors; the Radiant's
+antique blessing over the food, his warmth on the subject of service; the
+Hollow's flat answers and his hunger, watching the kitchen family belong to each
+other — are the **tells** that arm the Fractures, and Chapter V lays them out as
+a table with places and times. Salt them generously. Every tell a player
+witnesses is a person glimpsed through a mask, and at midnight each one becomes
+a key.
+
+### Tavva — the Other Thief
+*Somewhere in her forties, somewhere from the coast, somewhere on every festival
+hiring list under a different name. Tonight she is a steward in Boranis livery,
+and she has been planning this room for a season.*
+
+**Wants:** the trophy gallery — the portable case of it, anyway. The first open
+Boranis door in two years is a professional opportunity that will not come twice,
+and there are buyers (she has never asked whose coin; that is what intermediaries
+are for) with a standing interest in old soul-crystals. **Fears:** wards, which
+she respects the way sailors respect weather — and, mounting all evening, this
+house itself: she has robbed enough palaces to know what a prepared one feels
+like, and this one feels *aimed*. **Secret:** her crew of four came in as festival
+hires across two nights, her timetable keyed to the Dead Dance's lowered lamps.
+The midnight attack is nothing to do with her — she is as blindsided as the
+ministers — but she is a professional, and when the ceiling of the world falls in
+on her carefully planned burglary, she takes the chaos as a gift and works it.
+
+**Play her:** unhurried, courteous, forgettable on purpose — the second-best
+unmemorable performance in the palace, and the module notes she would be
+genuinely offended to learn it. She fights only to leave, bargains fast and
+honestly when cornered, and abandons any prize that starts costing blood. Her
+crew's three sightings are in Chapter IV; the raid itself is in Chapter V. Caught
+and held — tonight or by the inquest — she is a gold mine of exactly the wrong
+information: she can prove she planned the gallery job for a season, which makes
+her the aftermath's most convenient scapegoat, and she knows it before her
+questioners do. *(Stat files: `enemies/tavva.fof`, `enemies/gallery_knife.fof`.)*
+
+### Otta Vesh — the Mask-Maker *(prelude wing)*
+The finest spirit-mask maker in Rekuzan; her workshop is Night One's best scene, and
+her wall of casting-blanks — one kept for every face she has ever fitted, her rite
+and her pride — is the thread that later proves the three gray masks came from no
+hand in the city. **Play her:** an artist at festival peak — imperious, overbooked,
+susceptible to nothing but genuine appreciation of the craft.

--- a/adventures/oraga_night/08_Appendix_Tribes_of_Valloh.md
+++ b/adventures/oraga_night/08_Appendix_Tribes_of_Valloh.md
@@ -1,0 +1,187 @@
+# VIII. Appendix — Tribes of Val'loh
+
+*A mini-Facet for playing in Val'loh, usable beyond this module. It replaces the core
+game's magic domains with the tribal gifts, and bends nothing else.*
+
+## How Magic Works Here
+
+**There are no magic domains in Val'loh.** Two things fill that space:
+
+**Spellforms** — formal magic, drawn thread by luminous thread in the air by the
+gifted and the trained. Spellforms are *slow*: a working light takes an hour of
+focused construction; anything impressive takes days. Treat spellcraft as downtime
+work (Lore, Craft, or Attune rolls across days), never as an action. Nobody casts in
+a crisis. Ever. Players raised on other games will test this; the world holds.
+
+**Gifts** — inherited tribal abilities, always on, always fast. Every tribe carries
+one, passed through blood, present in some fraction of its people. A gift is not
+spellcraft; it is a sense or a knack, as native as sight.
+
+The one exception that runs civilization: **Orthaen crystals** hold finished
+spellforms and release them at a touch. Stored magic is fast magic — which is why
+crystal is wealth, why Rekuzan glows, and why the Orthaen sit at the top of Val'loh.
+
+## Building a Val'loh Character
+
+Build normally (Player Handbook, Chapter II) with one substitution:
+
+1. Choose a tribe below. It shapes who you are; it is not a profession. **For
+   Oraga Night, player characters are Orthaen — or, rarely and with MM
+   agreement, Phern.** The remaining tribes are statted for the MM's cast and
+   for other adventures in Val'loh.
+2. Take any Background as usual — soldier, trader, chronicler, courtier, thief.
+3. **If your character is gifted, the gift replaces the Background's secondary
+   skill** (exactly as magic-granting Backgrounds replace it in the core rules).
+   **If ungifted, keep the standard secondary skill** — and take heart: most of
+   Val'loh is ungifted, and runs it anyway.
+4. Take a Specialty as usual; each tribe entry suggests fitting ones.
+
+**On being ungifted:** how the ungifted are treated tracks the gift's rarity. Where
+nearly everyone is gifted (Dekhi, Phern, Scora), the ungifted few are pitied or
+worse. Where the gift is rare (Thenya, Kshalo), the ungifted are simply the tribe.
+This is texture, not mechanics — but it is load-bearing texture, and worth a line in
+any Val'loh character's story.
+
+---
+
+## The Tribes
+
+### Orthaen — the Crystal Tribe
+*The dominant tribe of the central farmlands; holders of Rekuzan; four in five carry
+the gift.* Proud, cautious, patient the way only people who build in centuries can
+be. Their politics run through eight great sects; their architecture is their
+ancestors, still standing.
+
+**Gift — Soul-Crystals.** A gifted Orthaen grows and charges small crystals that
+hold finished spellwork — a few carried charges, each a single minor working
+declared when it was grown: steady light, seal a door, a veil of quiet, a chime
+at a threshold, warmth, a held image. This is flair, not a subsystem: releasing a
+charge just happens, charging one is a quiet evening's downtime, and anything
+chancy or ambitious is an ordinary 2d6 roll (usually Attune) at whatever
+difficulty the fiction earns. When the gift bears directly on a task — reading
+crystalwork, coaxing a ward, judging grown architecture — the roll is **Easy**.
+The fiction is the limit, and the MM's difficulty ladder is the whole rules text.
+**Suggested Specialties:** sect heraldry and old grudges; crystalwright's
+appraisal; the etiquette of the eight houses.
+
+### Phern — the Travelling Tribe
+*No holdings, no wish for any; small (rarely past five feet), quick, and nearly all
+gifted; the caravan roads of Val'loh are theirs.* Traders and go-betweens welcome
+almost everywhere, trusted precisely as far as their contracts. A couple of
+high-ranking Phern hold seats on Rekuzan's Merchant's Circle — the only reason a
+Phern is at this ball at all.
+
+**Gift — Danger-Sense.** Hidden danger announces itself. Play it as flair the MM
+reaches for freely — "your neck prickles," direction and nature unspecified — and
+as a standing difficulty shift: rolls to sense ambush, tail, or trap are **Easy**,
+and a Phern is never treated as simply unaware when it matters. No tracking, no
+uses-per-scene; the gift is a fact about the character the way sharp eyes are.
+**Suggested Specialties:** contracts and caravan law; smugglers' roads; the fair
+price of anything.
+
+---
+
+## The Other Tribes of Val'loh
+
+*NPCs, patrons, rumors, and future adventures. Statted so a Val'loh campaign can
+grow past one night — not options for Oraga Night's player characters.*
+
+### Thenya — the Bonded Tribe
+*A diminished people of the southwest, holding their single ancestral citadel;
+famously handsome, famously blunt; fewer than one in a hundred gifted.* Border
+folk who measure words like water and keep faith like stone.
+
+**Gift — The Bond** *(vanishingly rare — in 3164 the gifted Thenya alive can be
+counted on one hand, and one of them is dancing at the center of this module)*.
+When someone a gifted Thenya loves faces death before their eyes, the world can
+bend — the blow turns, the fall catches, the last thread holds. It needs no
+training and obeys no technique; it is love, weaponized by ancestry. Resolve it
+as a Spirit roll when the moment comes, at whatever difficulty the fiction earns,
+and let it cost something on a partial.
+**Suggested Specialties:** border survival; the reading of intentions; the
+histories and debts of the Thenya line.
+
+### Scora — the Remembering Tribe
+*Wanderers and storytellers, all of them gifted; they sew what matters into their
+robes and carry the continent's memory between its peoples.* Welcome at every fire,
+belonging to none.
+
+**Gift — The Weave.** Perfect recall of anything witnessed or recorded, and a
+pattern-sense that connects the thing in front of them to the history they carry.
+Rolls to remember, connect, or recognize are **Easy**; on a strong success, let a
+Scora ask one true question of the past.
+**Suggested Specialties:** the collected history of a chosen house, tribe, or
+question (choose it precisely — a Scora's Specialty is a life's thread).
+
+### Akathi — the Blade-Bonded
+*A small southern coast tribe, old beyond their own records, athletic by blood;
+half carry the gift.* They defend little territory ferociously and hire out their
+blades with clear consciences.
+
+**Gift — Weapon-Bond.** One weapon, bonded over a season, is part of them: it can
+always be found again, always finds its way back to hand, and fighting with it is
+where the gift lives — rolls made with the bonded weapon in a fight it was made
+for are **Easy**.
+**Suggested Specialties:** the mercenary trade; reading a room for exits and
+weapons; the forms and their counters.
+
+### Dekhi — the Enduring
+*Northern foothill folk, heavy-built, winter-proofed; the gift is nearly universal
+because its lack is rarely survivable.* Slow to speak, impossible to move.
+
+**Gift — Endurance of Stone.** Cold, poison, hunger, and exhaustion simply find
+less purchase. Rolls to *endure* — hold the wall, carry the wounded, outlast the
+storm — are **Easy**, and environmental hardships that would drop others land a
+tier softer on a Dekhi.
+**Suggested Specialties:** winter-craft; the guarding of bodies and doors; the
+northern passes.
+
+### Kshalo — the Dreamers
+*Reclusive folk of the northwest foothills; feared by every other tribe, which
+suits them; one in twenty gifted, many weakly.* They did not come down for the
+festival. If you are here, you are far from home, and people watch you.
+
+**Gift — Dream-Walking.** Sleeping near someone they have met — or holding
+something truly theirs — a gifted Kshalo can walk that person's dream: ask it
+questions, leave impressions that survive waking. Resolve it as a Spirit roll at
+night, answers arriving in dream-logic, consequences arriving when the dream
+notices. Other tribes fear this more than it usually deserves, which suits the
+Kshalo fine.
+**Suggested Specialties:** the meaning of dreams; herb-lore of sleep and waking;
+being politely, professionally feared.
+
+### Fthala — the Forest Tribe
+*Dwellers in every great wood of Val'loh regardless of whose banner claims it;
+tall, quick, quiet; routing them has never once been worth the effort.* (Some
+canon records spell them **Vethala**; both are heard on the roads.)
+
+**Gift — Wildspeech.** They speak with animals, always — the animals answer as
+themselves, at their own wit — and a small, loyal companion beast usually travels
+with them. Rolls to move, hide, or live in wild country are **Easy**.
+**Suggested Specialties:** the forests of a region; beast-lore; paths that are not
+roads.
+
+---
+
+## Tribes You Will Hear Of, But Not Play
+
+**The mountain tribes** keep to the western and northern high country and did not
+come down for anyone's festival — the Tyndi gadget-wrights among them are a story
+traders tell, and the far side of the mountains belongs to **Mazaa**, the rainless
+land where the ungifted build machines that act like magic. And elders speak,
+carefully, of tribes that are *gone* — names that come up at Oraga, when the dead
+are honored, and are not explained to children. Val'loh is old, and its memory has
+holes in it that nobody made by accident.
+
+---
+
+## A Note on the Gifts (for the MM)
+
+The gifts run entirely on the core game's machinery — difficulty shifts,
+Specialties, ordinary 2d6 rolls, and the gift-replaces-secondary-skill pattern
+that magic-granting Backgrounds already use. There are no charges to track, no
+uses per scene, no new subsystems: a gift is a true fact about a character, the
+way sharp eyes or a famous name are true facts, and it earns Easy when it bears
+directly on the task. In this adventure the gifts are mostly flair — the crystals
+are texture and toolkit, the danger-sense is dread on tap — and the one rule that
+matters is the setting's: gifts are always fast, spellforms never are.

--- a/adventures/oraga_night/09_Handouts.md
+++ b/adventures/oraga_night/09_Handouts.md
@@ -1,0 +1,182 @@
+# IX. Handouts and the Night-Tracker
+
+## Handout 1 — The Invitation
+
+*Reproduce on good paper if you can. An interactive rendering exists in the setting
+archives (`docs/invitation.html`); the text is canonical:*
+
+> **HOUSE BORANIS**
+>
+> *To My Esteemed Guest,*
+>
+> It is my great honor to invite you to the seat of our people, the Palace Boranis,
+> for a night of revelry in the bounty bestowed upon our lands on the last night of
+> Oraga. I look forward to seeing you all and sharing food, drink, and revelry with
+> you among the spirits as we look forward to a bright future.
+>
+> *Given Under My Hand,*
+> **Raunu Boranis**
+
+---
+
+## Handout 2 — Agenda Cards
+
+*Cut apart; deal one per player. Full text and the private "At midnight" notes are
+in Chapter III — these cards carry only what the character knows.*
+
+**1. THE CIRCLE'S RECKONING** — *They call it "the Tithe of Hands." Learn what the
+chief's new decree does before it is proclaimed. The Circle pays for foresight.
+— R.C.*
+
+**2. THE PRELATE'S QUESTION** — *One question, answered honestly, and the Church
+owes you a favor you may spend anywhere: is the man who came back the man who
+left? — D.K.*
+
+**3. A HOUSE'S LONG GAME** — *Vorlain ruled for a year and handed it back. Find
+out if he misses the taste. Get him to say anything we could later call an
+understanding. — E.D.*
+
+**4. THE COUSIN'S ERRAND** — *These words, learned by heart, and her grandmother's
+ring, into Veier's own hands — no minister, no husband, no exceptions. Bring back
+her answer, word for word. Bring back the truth of how she fares. — M.N.*
+
+**5. THE UNPAID DEBT** — *Grandmother's soul-crystal hangs in their trophy gallery
+like a hunting prize. It took her sixty years to grow. Take it home.*
+
+**6. THE GATE AT MIDNIGHT** — *Triple rates, in old coin, for one small thing: the
+river gate at the bottom of the garden, unlocked at midnight. Not before. No
+questions.*
+
+**7. THE STORY OF A LIFETIME** — *The mists fall, the silent house opens, the
+vanished chief throws a ball. Every thread knots in that palace tonight. Witness
+truly. Get the testimony out alive.*
+
+**8. THE VANISHED SERVANT** — *Anha's word home stopped coming with the festival
+carters when the staff was cut, two years ago. She was not among the dismissed.
+Tonight the doors are open. Find her.*
+
+---
+
+## Handout 3 — The Rumor Table
+
+*Roll 2d6 in any social scene, or choose. Every rumor is delivered with total
+confidence. None is confirmed. Several cannot all be true, which bothers nobody
+telling them.*
+
+**Table IX–1: Rumors at the Ball**
+
+| 2d6 | What they're saying behind the masks |
+|---|---|
+| 2 | He never left. The man who "returned" is the man who never went anywhere — test him on the old days and watch his eyes. |
+| 3 | He walked into the eastern mists and the mists gave him back. That's why they've fallen — they're *empty* now. He brought back what was in them. |
+| 4 | The Church took him for a year of questioning and returned him hollowed. Why else would the Prelate herself attend a house the Church despises? |
+| 5 | He went beneath the palace, where the first Boranis crystal was grown, and slept a year in the root of the house. The walls feed him now. That's why the staff was cut — fewer eyes. |
+| 6 | The Thenya bride is already dead, and tonight's "announcement" will be a changeling got on some serving girl. The Thenya delegation knows — watch how they don't drink. |
+| 7 | *(The common one.)* The marriage is coin, plain and simple: the Thenya paid their last treasure for their border, and the recluse wanted an heir nobody could refuse. Everything else is theater. |
+| 8 | Vorlain has never stopped ruling. Raunu is a mask his brother wears when the seat needs a beloved face. Two chiefs, one house — count who the ministers *actually* bow to. |
+| 9 | A Kshalo dreamed him away, and he bargained his way back with something he'll spend the rest of his life paying. The offerings in Elanna's niche? That's the interest. |
+| 10 | He crossed the mountains and saw Mazaa — walked among the godless machines — and came home to make the Orthaen ready for what's coming west. The new decrees are war logistics wearing worker's clothes. |
+| 11 | The staff weren't dismissed. They're still *in* there. Ask yourself why the east wing needs guards on the inside of the doors. |
+| 12 | He found something in his year away that told him the day he'll die. Everything since — the pact, the bride, the silence, this ball — is a man setting his affairs in order. *(Deliver this one straight. Let the table sit with it at dawn.)* |
+
+---
+
+## Handout 4 — The MM's Night-Tracker
+
+*One page. Run the ball from here.*
+
+### The Program
+
+**Table IX–2: The Program of the Night**
+
+| Mv | Name | Scheduled | The Omen |
+|---|---|---|---|
+| I | The Receiving Line | Gates open; Corval checks names from memory; masks on; blades stay (nobody checks); hosts absent | Nine honor guards — facing *inward* |
+| II | The Empty Rooms | Vorlain holds court; factions circulate; hosts still absent | Corro's gift rings, pointing nowhere |
+| III | The Summons | A glimpse on the high gallery; Corval fetches chosen guests (≥1 PC) to the empty Audience Hall, one at a time | Three gray masks Corval cannot account for; the question won't stay in his head |
+| IV | The Toast | Dinner; Raunu appears unannounced; the awkward toast — *"At the Unmasking I will have something to say"* — then **two plates** and gone | The mews scream, then silence; the gardens go quiet |
+| V | The Hour of Spirits | Lamps low; the Dead Dance; quarter-bells; everyone knows custom compels the host back at midnight; Vell walks to the river gate | A cold partner in the dance: *"You dance like my daughter would have."* |
+| VI | The Unmasking | **Midnight.** Raunu returns to the dais; the rite; the promised words begin — and the lights die **mid-sentence**. He never gets to make the announcement | — |
+| VII | The Longest Night | Fire, rescue, the counting; guards arrive; word of other attacks | — |
+
+### Where Everyone Stands (Movements I–V)
+
+**Table IX–3: Where Everyone Stands**
+
+| NPC | I | II | III | IV | V |
+|---|---|---|---|---|---|
+| Raunu | *(unseen — B8/B9)* | *(unseen — B8/B9)* | high gallery glimpse, then B4 (summonses) | B3 high table — the toast, two plates, gone (B9) | B9 with Veier; descends at the bells |
+| Veier | B9, her rooms | B9, her rooms | B9 (reachable via Agenda 4 / Und. C only) | B9 — dinner for two, upstairs | B9, guard doubled |
+| Vorlain | B2 | B3 wine court | B3, watching the audiences | B2 — watch his face | B3, drinking harder |
+| Corval | B1 gate | everywhere | B1/B2 | B2 | doubles east wing guard |
+| Kovaun | B1 line | B2 census | B4 antechamber | B2 | B6 chapel, briefly |
+| Sella | B6 | B6 | B6 | B2 for the toast | B6 — masks rite prep |
+| Callun | B1 line | B3 alcove w/ Corro | B3 | B2 — recalculating | B3 |
+| Corro | B2 | B3 alcove — *uneasy* | B2 — *worse* | B2 — *bad* | B2, back to a wall |
+| Draunel | B2 | B3 | B4 line, courting | B2 | B3 |
+| Essin | with Vorlain | with Vorlain | with Vorlain | with Vorlain | with Vorlain |
+| Maiven | B1 — impatient | B3 pressing Corval | B3 petitioning for a summons | B3 — the toast lands like a slap; audience refused | B2/B9 doors — one bad hour from the wall |
+| Anha | B10 | B10 | B10 | B10 (watching from the service door) | B10 |
+| Vell | B1, unmemorable | B5 gardens once | B2 edge | B2 edge | B5 — the river gate |
+| Tavva | B1, hired livery | B10, learning the halls | scout walks B7 corridor | B3, unremarkable | dark corridors — staging |
+| The Uninvited | — | — | B2 edge, arriving | B2 edge, still | Wept: east doors · Radiant: the Dance · Hollow: exits |
+
+### Undercurrents (Movements II–V)
+
+**Table IX–4: The Undercurrents**
+
+| Thread | Spark | Trail runs through | Bottom |
+|---|---|---|---|
+| A. The Root of the House | rumor 5 · Anha's barred stair · study slate (B8) | cellar tally-cords → wine-cellar seam → lattice key | the laboratory (B11): gift-source research, the recall-lattices, the observation lattices, orrery of two bloodlines, *"Both rivers, one spring."* |
+| B. The Household That Wasn't | Agenda 8 · the returned footman · arithmetic | footman's story → Corval's recitation → the sworn testament | the staff were *evacuated*, with love and logistics; the remainers are volunteers |
+| C. The Third Plate | Anha's fact · the small linens · rumor 11 | the midwife → east wing doors → the nursery | the pregnancy, before the trumpets — foreknowledge, and what it costs |
+| D. The Guests Who Cast No Gossip | Corval's failing count · Corro's compass · no gossip | Corval's slipping mind → walking Corro → mask-craft/Vesh's blanks → the cold dance | certainty before midnight; Fracture ammunition; Raunu's *"I know."* |
+
+### Optional Steel (opt-in fights — all visible, none mandatory; Ch. IV)
+
+**Table IX–5: Optional Steel**
+
+| When | What they see | The fight |
+|---|---|---|
+| Mv II–IV | The seating feud boils over in B3 — a thrown cup, a circle forming | Joinable brawl, Tier 1 bruising; bare steel brings guards |
+| Mv III | A footman in ill-fitting livery counting the gallery guards (B7) | Follow or brace the scout — `gallery_knife.fof` |
+| Mv V | Figures with rope and sacking in the dark service corridors | Knives in the dark, hushed on both sides — the crew, staged |
+| Mv VI–VII | Looters working the gallery (B7) and the fallen (B3) | **The winnable fight** — `tavva.fof` + crew, Ch. V beats |
+| Any | Players cross the house — heist gone loud, east wing forced | Guards detain-and-expel, 2–3 exchanges, outs visible (Ch. IV sidebar) |
+
+### Crisis Panel (Movement VI)
+
+**Trigger:** mid-speech, on the dais, as the promised announcement begins.
+**Assignments:** Wept → Raunu (B2 dais). Radiant → Veier (B9 → private stair →
+B5: **the Crossing**, where Vell meets it — crossfire rules, Ch. V). Hollow →
+main doors (B2), herding. Vell → service passages → garden stair → river gate (B5).
+
+**You cannot beat them:** Resolve 0 ≠ kill — it stops indulging, removes the
+obstacle (Tier 2, out of scene), resumes; Resolve resets. Force buys time; only
+ward-fire, the leash, and Fractures change outcomes.
+
+**The palace fights back:** barriers seal corridors; light floods stairwells; ward
+over huddled guests. Agenda-5 player reads wards at Standard, others Hard.
+
+**Crystals near an Uninvited:** trigger only on Luck (Standard); 6− = dark.
+
+**Fractures (Ch. V — tell-table there):** Wept = sorrow (pages, chapel rite,
+cradle-song, "my daughter") · Radiant = devotion (antique blessing, "whom do you
+serve?"; deny the congregation or plant the doubt — guilt slows it; it cannot
+be turned) · Hollow = despair (exits, flat answers; sincerity, not ferocity).
+Soul action; 1 witnessed tell = Hard, 2+ = Standard; once each.
+
+**The leash:** ~half an hour of story. Late = faster, sloppier, more human. Ring
+the last bell when the table needs the end.
+
+**The Root (B11, if found):** master ward-valve; shelter for a dozen; the
+Uninvited will not enter.
+
+**The looters:** Tavva's crew hits the gallery (B7) and strips the fallen
+(B3/corridors) — the night's one fully winnable fight, aimed at the players'
+better natures. They flee when the price turns real; a captive is dawn's best
+evidence (Ch. V).
+
+**Canonical pillars:** Raunu falls (his last charge seals doors behind Veier all
+the way down) · Veier + Vell out the river gate · the Uninvited leave no trace ·
+no one is ever charged. Divergence sidebars: Chapter V.

--- a/adventures/oraga_night/README.md
+++ b/adventures/oraga_night/README.md
@@ -1,0 +1,59 @@
+# Oraga Night
+
+*A masquerade adventure for Facets of Origin. One night, one palace, two hundred masks,
+and three guests nobody invited.*
+
+**Setting:** Rekuzan, capital of the Orthaen, continent of Val'loh — 3164 PG
+**Players:** 3–5, fresh characters or the included pregens
+**Length:** One session (4–6 hours) as written; 3–4 sessions with the optional wings
+**Tone:** Glamour over a blade — festival splendor and social fencing, with something
+wrong accumulating underneath
+
+---
+
+## What This Is
+
+House Boranis has been silent for two years. Its chief, Raunu — genius, maniac, or both —
+vanished for a year, returned without explanation, married across tribal lines, and shut
+his palace to the world. Now, on the final night of the Oraga harvest festival,
+invitations have gone out for a masquerade ball.
+
+Everyone of importance loathes Raunu Boranis. Nearly all of them will come anyway.
+
+The player characters come too — invited, hired, smuggled, or holding an invitation that
+was never meant for them. Each carries an agenda into the Crystal Court. None of them
+carries the right one, because the night has an agenda of its own.
+
+## Contents
+
+| File | What it is |
+|---|---|
+| `01_Overture.md` | How to run this module — tone, structure, canon, safety |
+| `02_The_World_and_the_Night.md` | Val'loh, Rekuzan, House Boranis, and what is really happening |
+| `03_Masks_and_Agendas.md` | Character creation, invitations, masks, and the eight agendas |
+| `04_The_Ball.md` | The palace, the guests, and the seven Movements of the night |
+| `05_The_Longest_Night.md` | The Unmasking — the attack, the Fractures, and every ending |
+| `06_Wings.md` | Optional prelude (festival Nights One and Two) and aftermath chapters |
+| `07_Cast_of_the_Ball.md` | Every named NPC — wants, fears, secrets, and how to play them |
+| `08_Appendix_Tribes_of_Valloh.md` | Mini-Facet: the mage tribes as playable Backgrounds and gifts |
+| `09_Handouts.md` | The invitation, agenda cards, rumor table, and the MM's night-tracker |
+| `enemies/*.fof` | Stat files for the Uninvited |
+
+## Running Order
+
+Read `01` and `02` fully. Skim `04` and `05` once, then run from the night-tracker in
+`09` with `07` open for the cast. If your table wants the short campaign, start with
+`06`'s prelude nights instead of at the palace gates.
+
+## A Note on Secrets
+
+This night is the opening move of a much larger story. The module deliberately does not
+tell you all of it — not to tease you, but because those answers belong to the setting's
+future, and no table needs them to run an unforgettable night. Everything required to
+play every scene is in these pages.
+
+## License
+
+Part of the Facets of Origin project, released under GPLv3 (see repository root).
+The world of Svara and all its canon belong to the setting's author and appear here
+by that author's hand.

--- a/adventures/oraga_night/enemies/boranis_honor_guard.fof
+++ b/adventures/oraga_night/enemies/boranis_honor_guard.fof
@@ -1,0 +1,68 @@
+fof_version: '0.1'
+type: enemy
+id: boranis_honor_guard
+name: Boranis Honor Guard
+
+ruleset:
+  modules:
+  - id: base
+    version: 0.1.0
+
+enemy:
+  tier: named
+  resolve: 3
+  attack_modifier: 2
+  defense_modifier: 2
+  armor: light
+  techniques: [warder]
+  special: >
+    WARDER — each honor guard carries two charged house crystals (a seal and a
+    flare) and knows the palace's ward-points by heart. In a crisis they fight
+    to positions, not to kills.
+  tr: 9                 # offense(+2→4) + durability(Resolve 3) + armor(light→1) + techniques(1) = 9
+  phases: []
+
+  disposition: >
+    Household soldiers, good at their work, entirely certain they are in
+    the right.
+
+  first_target: >
+    Whoever is between them and the room being crossed.
+
+  morale: >
+    Surrender ends it. It costs the evening — mask, invitation, and the
+    rest of the night in the gatehouse cell — and not the character.
+
+  organization: >
+    Nine on the night of the ball, placed inward, facing the palace
+    doors.
+
+  triggers:
+    - >
+      Fights to detain and expel, never to kill.
+    - >
+      At midnight the nine die or fall protecting their chief, around
+      the edges of the frame — scripted regardless of these numbers
+      (Chapter V).
+
+  description: >
+    One of the nine. The Boranis honor guard should number forty at an event
+    like this; the nine on duty tonight are the ones Raunu judged he could not
+    make leave, and they stand facing the palace doors, not the gates. Veterans
+    to the last, courteous to guests, and entirely without illusions about
+    what they signed up for — though even they do not know what is actually
+    coming.
+
+  notes: >
+    Use this block if players cross the house itself: forcing the east wing,
+    robbing the trophy gallery loudly, or refusing the gatehouse cell. Honor
+    guards fight to detain and expel, and they are good enough that a starting
+    party should feel it.
+
+    AT MIDNIGHT they die or fall protecting their chief — quickly, around the
+    edges of the frame (module Chapter V). That outcome is scripted regardless
+    of these numbers; the stat block exists for the hours before the bells,
+    or for tables whose plans put them beside the nine when the lights die.
+
+created_at: '2026-07-12T00:00:00+00:00'
+last_modified: '2026-07-12T00:00:00+00:00'

--- a/adventures/oraga_night/enemies/gallery_knife.fof
+++ b/adventures/oraga_night/enemies/gallery_knife.fof
@@ -1,0 +1,66 @@
+fof_version: '0.1'
+type: enemy
+id: gallery_knife
+name: Gallery Knife
+
+ruleset:
+  modules:
+  - id: base
+    version: 0.1.0
+
+enemy:
+  tier: mook
+  resolve: 0
+  attack_modifier: 1
+  defense_modifier: 1
+  armor: none
+  techniques: []
+  special: null
+  tr: 3                 # offense(+1→3) + durability(0) + armor(none→0) = 3
+  phases: []
+
+  disposition: >
+    Paid for a burglary, not a war, and entirely clear on the
+    difference.
+
+  first_target: >
+    Whoever is between them and the service passages.
+
+  morale: >
+    One good hit — any Condition, or a lost exchange — usually makes one
+    drop the sack and run. They will not kill a downed opponent, and
+    they will not stand with Tavva past the point she would leave
+    herself.
+
+  organization: >
+    Two to four working a floor, with Tavva somewhere else entirely.
+
+  triggers:
+    - >
+      Opens with a slash to make space, then leaves.
+    - >
+      A fight in the dark is hushed on both sides — whoever makes
+      noise answers to the guards, and everyone in the corridor knows
+      it.
+
+  description: >
+    One of Tavva's crew — four of them tonight, in borrowed livery that fits
+    like a borrowed coat. Housebreakers and purse-cutters, quick, practical,
+    and brave about property rather than people. At midnight two work the
+    trophy gallery and two work the smoke, stripping rings and masks from the
+    fallen.
+
+  notes: >
+    CONDUCT: a gallery knife fights to disengage — a slash to make space, then
+    the service passages. One good hit (any Tier of Condition, or a lost
+    exchange) is usually enough to make one drop the sack and run; they are
+    paid for a burglary, not a war. They will not kill a downed opponent, and
+    they will not stand with Tavva past the point she herself would leave.
+
+    Use this block for the scout in Movement III, the staging scuffle in the
+    Dead Dance (both module Chapter IV), and the midnight raid (Chapter V).
+    A fight with the crew in the dark is hushed on both sides — whoever makes
+    noise answers to the guards, and everyone in the corridor knows it.
+
+created_at: '2026-07-13T00:00:00+00:00'
+last_modified: '2026-07-13T00:00:00+00:00'

--- a/adventures/oraga_night/enemies/sect_guard.fof
+++ b/adventures/oraga_night/enemies/sect_guard.fof
@@ -1,0 +1,60 @@
+fof_version: '0.1'
+type: enemy
+id: sect_guard
+name: Sect Guard
+
+ruleset:
+  modules:
+  - id: base
+    version: 0.1.0
+
+enemy:
+  tier: mook
+  resolve: 0
+  attack_modifier: 1
+  defense_modifier: 1
+  armor: light
+  techniques: []
+  special: null
+  tr: 4                 # offense(+1→3) + durability(0) + armor(light→1) = 4
+  phases: []
+
+  disposition: >
+    Festival watchmen. Their first instinct is volume and numbers, not
+    blades.
+
+  first_target: >
+    Whoever drew steel, and only them.
+
+  morale: >
+    Never fights past compliance. A dropped weapon ends it on the spot.
+
+  organization: >
+    Patrols in fours; a disturbance draws every four within earshot.
+
+  triggers:
+    - >
+      Answers brandished steel with four more guards inside two
+      exchanges.
+    - >
+      Subdues and ejects; does not kill guests unless guests are
+      killing.
+
+  description: >
+    A house guard of Rekuzan's sect palaces — trained, sober on duty, and far
+    more interested in ending trouble than in winning fights. Sect guards work
+    in pairs at minimum and shout for more before they draw.
+
+  notes: >
+    CONDUCT: guards subdue and eject; they do not kill guests unless guests
+    are killing. Their first response to brandished steel is numbers and loud
+    voices, not blades. A player character who fights one guard fights four
+    within two exchanges, and wakes up in the gatehouse cell having lost their
+    mask, their invitation, and their evening — which, depending on the hour,
+    may be the worst thing that has ever happened to anyone.
+
+    Use this block for festival watchmen and street patrols in the prelude and
+    aftermath wings as well.
+
+created_at: '2026-07-12T00:00:00+00:00'
+last_modified: '2026-07-12T00:00:00+00:00'

--- a/adventures/oraga_night/enemies/tavva.fof
+++ b/adventures/oraga_night/enemies/tavva.fof
@@ -1,0 +1,77 @@
+fof_version: '0.1'
+type: enemy
+id: tavva
+name: Tavva
+
+ruleset:
+  modules:
+  - id: base
+    version: 0.1.0
+
+enemy:
+  tier: named
+  resolve: 3
+  attack_modifier: 2
+  defense_modifier: 2
+  armor: light
+  techniques: [vanisher]
+  special: >
+    VANISHER — Tavva carries two bought crystal charges (a dark-burst and a
+    door-seal) and spends them only to break contact. When either fires, she
+    and anyone of her crew in reach are simply elsewhere by the next exchange
+    unless a player character spends their action staying on her.
+  tr: 9                 # offense(+2→4) + durability(Resolve 3) + armor(light→1) + techniques(1) = 9
+  phases: []
+
+  disposition: >
+    The finest working thief in Rekuzan tonight, mid-job when the world
+    fell in, professional enough to treat that as an opportunity.
+
+  first_target: >
+    Nobody. She fights to leave, and opens with feints and furniture.
+
+  morale: >
+    Cornered with no way out, she bargains fast and honestly: names, the
+    crew's routes, what she saw in the dark. All of it is true.
+
+  organization: >
+    Herself plus two to four gallery knives, never in the same room as
+    each other by choice.
+
+  negotiation: >
+    Wants out with something. Shifts for a clear exit or a better payer.
+    Honours any deal that ends with her walking and somebody else
+    holding the bag.
+
+  triggers:
+    - >
+      Spends a crystal charge only to break contact.
+    - >
+      Abandons any prize — including crew — that starts costing blood.
+
+  description: >
+    Steward's livery, coastal manners, a different name on every festival
+    hiring list. The finest working thief in Rekuzan tonight, mid-job when the
+    world falls in, professional enough to treat that as an opportunity. Full
+    entry in module Chapter VII; her crew's three sightings are Chapter IV;
+    the midnight raid is Chapter V.
+
+  notes: >
+    CONDUCT: Tavva fights to leave, never to kill. She opens with feints and
+    furniture, spends her charges to break contact, and abandons any prize —
+    including crew — that starts costing blood. Cornered with no way out, she
+    bargains, fast and honestly: names (not her buyers'; she does not know
+    them), the crew's routes, what she saw in the dark. All of it is true.
+
+    ENTIRELY WINNABLE: unlike nearly everything else abroad at midnight, Tavva
+    and her crew are a fight a starting party can flatly win. Resolve 0 means
+    exactly what the core rules say it means. Give the table this one clean
+    victory with both hands.
+
+    CAUGHT AND HELD: a captured Tavva is worth more than the goods — the
+    inquest's favorite scapegoat, the players' proof of what they saw, and a
+    season of professional observations about the palace that nobody else
+    thought to make.
+
+created_at: '2026-07-13T00:00:00+00:00'
+last_modified: '2026-07-13T00:00:00+00:00'

--- a/adventures/oraga_night/enemies/the_hollow.fof
+++ b/adventures/oraga_night/enemies/the_hollow.fof
@@ -1,0 +1,94 @@
+fof_version: '0.1'
+type: enemy
+id: the_hollow
+name: The Hollow
+
+ruleset:
+  modules:
+  - id: base
+    version: 0.1.0
+
+enemy:
+  tier: named
+  resolve: 4
+  attack_modifier: 1
+  defense_modifier: 2
+  armor: light
+  techniques: [fracture_despair, unraveling_presence, shadow_step]
+  special: >
+    THE LEASH — as the_wept.fof. THE POST — the Hollow holds the main doors and
+    herds the crowd; it never advances if holding will do.
+  tr: 11                # offense(+1→3) + durability(Resolve 4) + armor(light→1) + techniques(3) = 11
+  phases: []
+
+  disposition: >
+    Holds, never pushes. You cannot frighten something that would not
+    much mind ending.
+
+  first_target: >
+    The doors. It is not here to hurt anyone; it is here so nobody
+    leaves.
+
+  morale: >
+    Resolve 0 is never a kill. The only way to be rid of it early is its
+    Fracture — alone of the three, it can be driven off, because it
+    wants to go.
+
+  organization: >
+    One of three. Never acts without the other two on the field.
+
+  negotiation: >
+    Wants to stop. Shifts for sincerity and nothing else — ferocity is
+    useless. Honours its own departure: once turned, it goes home and
+    does not come back tonight.
+
+  triggers:
+    - >
+      Stands always nearest its own exit.
+    - >
+      Flinches from the palace's ward-fire the way a tired man
+      flinches from being asked to try.
+    - >
+      Fracture — Despair, once, at Hard: name the emptiness truly,
+      offer one honest moment of the belonging it was promised, or
+      simply tell it that it can stop. On a hit it opens its hands and
+      quits the field early. On 7–9 it lashes out once, hard, on its
+      way through the wall.
+
+  description: >
+    A blank gray spirit-mask — no features at all, which among two hundred
+    carved faces is the loudest mask in the room. He is a person: polite,
+    exhausted somewhere deeper than sleep reaches, answering small talk with
+    a flatness that ends conversations. All night he stood beside a different
+    exit, like a man permanently halfway to leaving. When midnight comes he
+    holds the great doors, and the crowd breaks around him like water.
+
+    He does not want to be here. He has not wanted anything, for a very long
+    time — which is precisely why he was chosen. He holds the doors because
+    holding is easier than wanting.
+
+  notes: >
+    FRACTURE — DESPAIR (once): ferocity is useless — you cannot frighten
+    something that would not much mind ending. SINCERITY works, at Hard: see
+    it; name the emptiness truly; offer one honest moment of the belonging it
+    was promised long ago and never given; or simply tell it, one person to
+    another, that it can stop. On a hit it stops — opens its hands, quits the
+    field early, the doors open, two hundred hostages stop being hostages. It
+    is the only one of the three that goes home before it is called. On 7–9
+    it lashes out once, hard, on its way through the wall.
+
+    TELLS: it flinches from the palace's ward-fire the way a tired man
+    flinches from being asked to try; it stands always nearest its own exit;
+    it holds but never pushes. Players who read crowds or guards (or a
+    bodyguard's Specialty) can be handed these free.
+
+    SHADOW-STEP: as the_wept.fof.
+
+    UNRAVELING PRESENCE: as the_wept.fof.
+
+    UNDEFEATABLE: as the_wept.fof — Resolve 0 is never a kill. The one true
+    way to be rid of the Hollow early is its Fracture: unlike its siblings,
+    it can be driven off the field by mortal ferocity, because it wants to go.
+
+created_at: '2026-07-12T00:00:00+00:00'
+last_modified: '2026-07-12T00:00:00+00:00'

--- a/adventures/oraga_night/enemies/the_radiant.fof
+++ b/adventures/oraga_night/enemies/the_radiant.fof
@@ -1,0 +1,102 @@
+fof_version: '0.1'
+type: enemy
+id: the_radiant
+name: The Radiant
+
+ruleset:
+  modules:
+  - id: base
+    version: 0.1.0
+
+enemy:
+  tier: named
+  resolve: 4
+  attack_modifier: 2
+  defense_modifier: 3   # fast — appallingly, beautifully fast
+  armor: light
+  techniques: [fracture_devotion, unraveling_presence, shadow_step]
+  special: >
+    THE LEASH — as the_wept.fof. THE HUNT — the Radiant's assignment is Veier;
+    it is faster than locked doors but not faster than witnesses.
+  tr: 12                # offense(+2→4) + durability(Resolve 4) + armor(light→1) + techniques(3) = 12
+  phases: []
+
+  disposition: >
+    Believes its service is worship, and worship must be witnessed to
+    count.
+
+  first_target: >
+    Whatever its errand names, and it re-stages the kill if nobody saw.
+
+  morale: >
+    It cannot be turned. Not by darkness, not by doubt, not by damage —
+    nothing short of the leash ends its errand. It can only be made to
+    feel, and guilt is slow, and slow is hallways.
+
+  organization: >
+    One of three. Takes the Dance while the others take the doors and
+    the dais.
+
+  negotiation: >
+    None. There is no deal here; that is the point of it.
+
+  triggers:
+    - >
+      Fracture — Deny the Congregation, at Hard: douse the lights,
+      empty the room, turn every back, or make someone else the better
+      spectacle. Unwitnessed, it hurries, stops savouring, and does
+      the work badly.
+    - >
+      Fracture — Plant the Doubt, at Hard: anyone armed with what they
+      have seen of its rites, declaring to its face that no god worth
+      the name asks for a stolen child. On a hit, guilt gets into the
+      errand — it falters at thresholds, looks back, re-stages kills.
+
+  description: >
+    A mirror-bright spirit-mask that catches every lamp in the hall. He is a
+    person — warm, courtly, genuinely delightful on the subject of duty — who
+    blessed his food in a form no priest has used in living memory and joined
+    the Dead Dance because he could not help himself. Of the three, he is the
+    one who moves like joy — and his kills, when they come, are staged, angled
+    toward the room, offered upward. Not showmanship. Liturgy. He believes
+    this errand is holy.
+
+    He hunts Veier Nolonaire through corridors that seal themselves behind
+    her, and he is losing time he does not have every moment somebody
+    WATCHES him.
+
+  notes: >
+    FRACTURE — DEVOTION (once): it believes revelations were spoken to it and
+    that its service is worship — which must be witnessed to count. THE
+    RADIANT CANNOT BE TURNED — not from the hunt, not by darkness or doubt;
+    nothing short of the leash ends its errand. It can only be made to FEEL.
+    Two roads in, either at Hard: DENY THE CONGREGATION (douse the lights,
+    empty the room, turn every back, or a Perform action that makes someone
+    else the better spectacle — unwitnessed, its service stops counting as
+    worship, and it hurries, stops savoring, does the work badly), or PLANT
+    THE DOUBT (a priest, a believer, or anyone armed with what they have seen
+    of its rites, declaring to its face that no god worth the name asks for a
+    stolen child). On a hit the words lodge: it does not stop or turn, but
+    guilt gets into the errand — it falters at thresholds, looks back,
+    re-stages kills. Guilt is slow, and slow is hallways; the margin at the
+    river gate is made of exactly this.
+
+    SHADOW-STEP: as the_wept.fof.
+
+    Conversely, witnesses SLOW it: every scene in which player characters
+    chase, harry, or simply see it buys Veier another hallway. Reward pursuit
+    with progress even when rolls fail — failure costs the pursuer, not the
+    escape.
+
+    UNRAVELING PRESENCE: as the_wept.fof.
+
+    UNDEFEATABLE: as the_wept.fof — Resolve 0 is never a kill; it removes the
+    obstacle and resumes the hunt. Force buys Veier hallways, nothing more.
+
+    THE CROSSING: at the climax the Radiant is intercepted in the gardens by
+    Master Vell — the one being at the ball it is wary of. It breaks past him
+    exactly once — unless guilt is already dragging at it, which is what its
+    Fracture is for. See module Chapter V.
+
+created_at: '2026-07-12T00:00:00+00:00'
+last_modified: '2026-07-13T00:00:00+00:00'

--- a/adventures/oraga_night/enemies/the_wept.fof
+++ b/adventures/oraga_night/enemies/the_wept.fof
@@ -1,0 +1,99 @@
+fof_version: '0.1'
+type: enemy
+id: the_wept
+name: The Wept
+
+ruleset:
+  modules:
+  - id: base
+    version: 0.1.0
+
+enemy:
+  tier: boss
+  resolve: 8
+  attack_modifier: 3    # it does not fight; it arrives — strength like a fact
+  defense_modifier: 2
+  armor: heavy          # not armor: wrongness. Blades land and matter less than they should
+  techniques: [fracture_sorrow, unraveling_presence, shadow_step]
+  special: >
+    THE LEASH — the Wept has roughly half an hour of story-time from the first
+    scream; when the last bell of Oraga rings, it leaves, finished or not.
+    Late in the attack it grows faster, sloppier, and more human.
+  tr: 18                # offense(+3→5) + durability(Resolve 8) + armor(heavy→2) + techniques(3) = 18
+  phases:
+    - resolve_threshold: 2
+      description: >
+        The Sorrow Slips. At Resolve 2 or below, the mask's carved tears begin to
+        run — actually run. Its blows land one tier softer, it starts to hum the
+        cradle-song mid-strike without knowing, and invoking its Fracture drops
+        from Hard to Standard. It is losing the argument with what it used to be.
+
+  disposition: >
+    Grief with a task. It does the work and takes no pleasure in any of
+    it.
+
+  first_target: >
+    Raunu Boranis, on the dais, and nothing else until that is done.
+
+  morale: >
+    Resolve 0 is never a kill. It leaves when its errand is finished or
+    when the leash calls it home.
+
+  organization: >
+    One of three. The others hold the doors and the Dance while it works
+    the dais.
+
+  negotiation: >
+    Wants the errand over. Shifts for nothing a mortal can offer
+    tonight.
+
+  description: >
+    The tallest of the three gray masks: a spirit-mask carved with falling
+    tears, warm sure hands, and the manners of a court two centuries gone. She
+    is a person — that is the thing to hold onto — a woman, gracious and
+    quietly sad, who praised the wine and danced beautifully. She leads. She
+    goes for Raunu Boranis and she does not hurry, because nothing at this
+    ball can stop her, and she knows exactly what that feels like from the
+    other side.
+
+    She watched the young pages at the feast a beat too long. She left a
+    mourner's offering in Elanna's niche, in a rite centuries out of date. She
+    lingered at the nursery doors humming a cradle-song no one living knows,
+    and told a dance partner, kindly, "You dance like my daughter would have."
+    Under the carved tears, the mask is a woman's face.
+
+  notes: >
+    FRACTURE — SORROW (once): a Soul-facet action at Hard (Standard in its final
+    phase), requiring ammunition gathered in play (the nursery, the cradle-song,
+    the question in the dance, the woman's face under the mask). The truth: she
+    was a mother; disease took her family while she stood helpless; tonight she
+    has been sent to inflict on a family what the world inflicted on hers. On a
+    hit, the Wept stops — mid-motion, mid-kill — and for one full beat it is a
+    person standing in a burning ballroom. On 7–9 it answers with one terrible
+    parting blow or word before it stops.
+
+    SHADOW-STEP: it slips through the world's shadow — short relocations that
+    read as arriving rather than running. Ordinary doors, walls, and barricades
+    do not reliably hold it; deep Boranis ward-crystal does.
+
+    UNRAVELING PRESENCE: within a stone's throw, triggered Orthaen crystal
+    charges work only on a Luck roll (Standard); on a 6− the charge dies dark.
+    The palace's great wards hold longer but gutter at close range.
+
+    CONDUCT: it has a task, not a body count. It steps around bystanders. It
+    kills whoever stands between it and its target — but a player character
+    about to die shielding Raunu is taken out of the fight (Tier 2 Condition,
+    a broken wall) rather than out of the world. It has no orders about them,
+    and no appetite.
+
+    UNDEFEATABLE: the Wept cannot be killed or beaten by force tonight — not
+    by the party, not by fifty guards, not by the palace. Resolve 0 is not a
+    kill: it stops indulging the interference, puts its attacker through a
+    wall (Tier 2 Condition, out of the scene), and resumes its task with
+    Resolve reset. Fighting it buys time with bodies — and time is real
+    currency (every exchange is a hallway Veier gains). Only ward-fire, the
+    leash-clock, and its Fracture change outcomes. See module Chapter V,
+    "You Cannot Beat Them."
+
+created_at: '2026-07-12T00:00:00+00:00'
+last_modified: '2026-07-12T00:00:00+00:00'


### PR DESCRIPTION
The first full adventure module — nine chapters, seven Movements, two hundred masks, and three guests nobody invited. Built as a campaign opening: the party arrives with an agenda each, the night runs its own clock whether or not they act, and one omen per Movement rewards anyone paying attention.

Structural work from the style-audit pass lands with it:

- the intro battery — party size, what you need, a Movement-by-Movement synopsis each ending in world-state, converging hooks, and a format legend
- eight triggered read-aloud blocks where the module previously had none
- printed Spark awards, so clever and peaceful play is paid on the page rather than left to MM generosity
- area codes renumbered to ascend in reading order

The seven module enemies carry typed conduct — disposition, first target, triggers, morale, and a negotiation surface where one exists. No fight in the module is to the death by default.

### Two review findings, both fixed

**The author's private worldbuilding notes are not in this repo.** An earlier version of this PR committed `references/oraga_night/` — source notes compiled from the private setting corpus, naming people, places, and events the module deliberately withholds. This repository is **public**. They are now gitignored and removed from every commit in the stack.

**The night-tracker reprinted a line the author had cut.** Handout 4's one-page tracker — the sheet the module tells the MM to run the ball from — still carried a Dead Dance line that had been cut and replaced. Chapter IV already used the replacement, so the tracker was putting the module's central secret on the page an MM reads aloud from. Fixed; the retracted wording appears nowhere.

Two read-aloud blocks were also tightened to the module's own rule — perception only, never what a character thinks or does.

**Deliberately deferred**, recorded as `docs/TODO.md` T5: the keyed-area field battery, maps, one-page scene cards, and the fiction prologue.

**Stacked PR 2 of 5.** Base is `feat/agentic-playtest-harness` (#18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
