### PR TITLE
B4: Technique steps compose, domains price by grant route, capstones override

### DIFF
--- a/docs/BRIEF_technique_difficulty.md
+++ b/docs/BRIEF_technique_difficulty.md
@@ -1,0 +1,153 @@
+# BRIEF — Techniques and the Difficulty Ladder
+
+**Tier:** Brain (Fable). **Input:** `docs/LOG_style_audit.md`, `## ESCALATION — Planner → Brain (2026-08-02)`.
+**Scope:** three rules questions surfaced by the `**Normal:**` field pass on all 57 Techniques. All three concern how a Technique's printed exception interacts with a baseline rule that is stated absolutely.
+
+---
+
+## Problem statement
+
+Adding a `Normal:` line to every Technique required stating the baseline each one departs from. Three baselines turned out not to exist in the text:
+
+1. Whether a Technique's "one difficulty step easier" composes with the MM's situational difficulty call (Q1).
+2. Whether *Second Domain*'s one-step penalty stacks onto the Broad table when a character also holds *Ascendant Domain* (Q2).
+3. Whether *The Final Blow* is subject to III.3's absolute "riders never defeat an enemy on their own" (Q3).
+
+Each has two or more individually defensible readings that produce different numbers at the table. The MM guide's own house standard (`style/STYLE_GUIDE.md:56` — discretion is delegated "with a default, a dial, and a guardrail") is currently unmet for all three.
+
+**Motivation for answering now, together:** all three are instances of one underlying question — *when a Technique states an exception, what does it compose with, and what does it override?* Answering them piecemeal invites the same silent divergence that invalidated the pre-v0.3 simulation corpus. Answering them once gives every future Technique a template.
+
+## Goals
+
+- A table-usable ruling for each question: default, dial where warranted, guardrail. No arithmetic beyond "move one label."
+- Rulings that leave the Series 7/9 simulation corpus (`research/simulation_log.md`) and the MM1 Encounter Recipe Table valid as published.
+- A composition doctrine that survives more Techniques, more Facets, and setting Facets without re-litigation.
+- An implementation posture for each ruling: engine-enforced, UI-assisted, or MM-facing prose only.
+
+## Non-goals
+
+- Wording the PHB/MM prose (Planner/Worker work; the one-sentence homes are named below).
+- Task decomposition, tests, or code.
+- Redesigning any Technique's effect. All six step-easier Techniques and *The Final Blow* keep their printed effects; the rulings define composition, not content.
+- The Pinnacle Technique framework (still an open blocker in `research/advancement_priority_questions.md`); Q3's doctrine is written so it will extend there, but that framework is not designed here.
+
+---
+
+## Q1 — Technique steps compose with the MM's situational call
+
+**The question.** Six Techniques make qualifying rolls "one difficulty step easier" (*Weapon Mastery* II.4a:55, *Steady Hand* II.4a:135, *Acclimated* II.4a:201, *Field of Mastery* II.4b:195, *Pressure Point* II.4b:95, *The Uncanny Angle* II.4c:123). III.1 has the MM declare a difficulty label, moving at most one step from the benchmark and saying so out loud (III.1:62–84; the style guide's formulation is "one step, never two," `style/STYLE_GUIDE.md:56`). Nothing states whether the Technique's step sits inside that budget or on top of it.
+
+### Options considered
+
+- **(a) Inside the budget.** The Technique's step consumes the MM's one-step adjustment; net movement from Standard is at most one rung. Weapon Mastery against a Defensive opponent: Standard.
+- **(b) On top, ordered, clamped.** The MM sets the situational label exactly as III.1 already instructs; the Technique then steps that label one easier; the four-rung ladder clamps. Weapon Mastery against a Defensive opponent: Hard (situational) → Standard (Technique).
+- **(c) Free composition.** Every step-shaped effect (Techniques, Support, future sources) accumulates.
+
+### Selected: (b), with a non-stacking guardrail on the character side
+
+**Default.** Difficulty is resolved in two moves, in a fixed order: **the MM's call first, the character's step second.** The MM declares the situational label per III.1 — benchmark, moved at most one step, said out loud. Set-to-label effects that define the situation (a Tier 2 rider making a target Easy to Strike, III.3:140; a 10+ Maneuver, III.3 *Maneuver*) are part of that call, not additions to it. Then any character-side "one step easier" effect the fiction supports applies to the declared label. The ladder clamps at Easy and Very Hard — a step off the end is simply absorbed.
+
+**Guardrail.** **Character-side steps never stack with each other.** A single roll benefits from at most one "one step easier" effect, whatever its source — Technique, Support's step option (III.3:173), or anything a future Facet prints. The player picks which if several apply. This is the exact shape of two guardrails already in canon: Support bonuses do not stack (III.3:175), and armor/reaction downgrades do not stack — "apply the greater reduction only" (III.3:410). Net result at any table: the MM moves one step, the character moves one step, never more. "One step, never two" remains true of the MM's own call, which is the sentence it was always about.
+
+**Dial.** Applicability, not arithmetic. The MM's lever is whether the Technique's fictional trigger is met — the chosen weapon type is in hand, the work is precision-under-pressure, the hunch is genuinely an impulse (*The Uncanny Angle* already says "The MM decides whether you are acting on instinct or strategy," II.4c:123). Once it applies, the step is automatic and fixed.
+
+### Why (b)
+
+1. **It is already the printed play pattern.** III.3's extended example rules it in so many words: "Standard difficulty, but Weapon Mastery makes this one step easier, so Easy" (III.3:513) — the Technique applied *after* the base was set. And the three one-step shifts implemented in `combat.py` (`maneuver_target_difficulty`, `enemy_posture_reaction_difficulty`, `target_strike_difficulty`, per the escalation's engine facts) are all single, non-composing shifts applied off a base label — (b) makes book and engine one doctrine.
+2. **Option (a) makes Tier 1 signatures evaporate exactly when they should matter.** Under (a), Weapon Mastery does nothing whenever the MM applies any hardship — the Technique's value would depend on the MM's difficulty call, which is feel-bad, litigable mid-scene, and contradicts the players-feel-competent register. It also makes Support's step option (identical wording) useless against any adjusted difficulty, which cannot be intended.
+3. **Option (c) is arithmetic at the table and compounds as content grows.** More Facets means more step sources; free stacking trends every specialist roll toward Easy and re-opens calibration with every supplement. The non-stacking guardrail caps the system's total drift at one rung forever, regardless of how many Techniques ship. This is the robustness argument from `research/dice_system_analysis.md:34` (modifier calculation ejects players from the fiction) and :43 (on 2d6, each ±1 is heavy — the reason PbtA-family modifiers must stay small and few).
+4. **Order is decidable and benign.** Clamping means opposite-direction steps only fail to commute at the ladder's ends (escalation fact 4). Fixing the order — situation first, character step last — resolves it, and since all six Technique steps are easier-direction, the only clamp interaction is at Easy, where the Technique harmlessly fizzles into an already-favorable position.
+
+### Downstream robustness (Q1)
+
+- **Simulation corpus: intact.** Series 7 and 9 ran `standard_party()`, which carries no step-easier Technique (skill modifiers only; `tools/combat_sim.py:973–981`). The ruling changes nothing the simulator models: base Strike difficulty stays Standard, rider→Easy stays a set. No recalibration required.
+- **Calibration honesty note (hand to Planner):** the Recipe Table is calibrated for baseline parties. A party where every front-liner strikes one step easier runs the table roughly a band hot — that was already true under any reading of Q1, because it is Technique power, not composition. MM1 gets one advisory sentence; the corpus's claims are unchanged.
+- **More content:** the guardrail is source-agnostic by construction ("at most one character-side step, whatever its source"), so new Facets and setting Facets inherit it without new rules text.
+- **If a table house-rules it away:** allowing stacking is a pure buff with a known bound (Easy floor); the ladder clamps, so nothing breaks mechanically — fights just run easier than the Recipe Table predicts. Acceptable failure mode; the MM1 note covers it implicitly.
+
+---
+
+## Q2 — The Second Domain penalty rides the Technique, not the domain count
+
+**The question.** *Second Domain* prices its granted domain "one difficulty step harder" (II.4b:259, II.4c:237). *Ascendant Domain* prices its prismatic territory off the Broad table — Hard / Very Hard / Very Hard, Major ceiling unmovable by Sparks (II.4b:271, II.4c:249; II.3:85, II.3:184). A character holding both Techniques has no written answer for workings in the prismatic domain: is it "a second domain," and therefore one step harder on top of the Broad table?
+
+### Options considered
+
+- **(a) Stack.** Any non-primary domain takes the step: prismatic Minor becomes Very Hard; Significant and Major clamp at Very Hard (no visible change).
+- **(b) No stack.** The one-step penalty is a property of the domain *granted by the Second Domain Technique*, priced on that domain's own table. Ascendant Domain's territory prices off the Broad table alone — the Broad table *is* the price of breadth.
+
+### Selected: (b)
+
+**Default.** A character's domains are priced by their grant route: the primary domain on its own type's table; the *Second Domain* grant on its own table, one step harder; the *Ascendant Domain* grant on the Broad table, with no additional step. Nothing in the system ever stacks a difficulty step onto the Broad table. Spark rules are untouched: dice-improvement Sparks work everywhere, and the Broad Major ceiling never moves (II.3:184).
+
+**Guardrail.** One prismatic territory per character, ever — already printed ("Ascendant Domain is taken once, however many Facet trees they eventually climb," II.4b:271/II.4c:249) — so "a second prismatic working" in the sense of a second prismatic *domain* has no route to exist. The composition question only ever arises in the one shape ruled on here.
+
+**Dial.** None. This is a fixed price, and should be — magic difficulty is the one place the game runs on published tables rather than MM judgment (MM2's whole magic-adjudication chapter depends on that).
+
+### Why (b)
+
+1. **Stacking is a rule that mostly doesn't exist and hurts when it does.** Under (a), two of three scopes clamp invisibly at Very Hard — a printed penalty with no effect, the precise anti-pattern MM2 already warns MMs against creating ad hoc (MM2:495, on accidentally applying the combat floor twice). The one visible effect, Minor at Very Hard, prices a prismatic *cantrip* like the hardest acts in the game — punitive, anti-fun, and hostile to the Technique that Tier 3 characters paid most for.
+2. **The Broad table already is the breadth surcharge.** II.3:85 frames it exactly so: "You trade reliability for range." Charging a second premium for the same breadth double-counts.
+3. **The engine already implements (b), deliberately.** `character.py:100–106` keeps `ascendant_domain` apart from `secondary_magic_domain` precisely because "the routes cost" differently, and `character.py:408–409` documents it: "ascendant_domain — prismatic, Broad table, no step penalty; secondary_magic_domain — Second Domain, one step harder." `engine.py:330–338` penalizes only `secondary_magic_domain`. Ruling (b) ratifies working, tested code; ruling (a) re-opens engine, tests, and canon to install the anti-pattern in point 1.
+
+**Latent wording defect, resolved in the same ruling:** *Second Domain*'s sentence "one difficulty step harder **than your primary domain**" (II.4b:259, II.4c:237) is anchored to the wrong table. Read literally, a Focused-primary character's second (standard) domain would price at Focused-table-plus-one — which equals the standard table, silently deleting the penalty. The engine's reading — the second domain's **own** table, one step harder — is the intended one and becomes canonical. The sentence in both chapters, `facet.yaml`'s roll text (`facet.yaml:830–833` and the Soul twin), and MM5:258 re-anchor to "one difficulty step harder than normal for that domain."
+
+### Downstream robustness (Q2)
+
+- **Simulation corpus: untouched.** Magic difficulty is not in the combat corpus.
+- **More content:** "the penalty rides the grant route" scales cleanly — any future acquisition route (a setting Facet's third tradition, a Pinnacle grant) declares its own price on arrival instead of inheriting an ambient your-Nth-domain tax. That is also why (b) survives the Body-magic tradition landing later.
+- **If a table house-rules it away:** stacking anyway is self-limiting (the clamp), and no engine invariant breaks — the app would simply show a different label than the MM announces, which the UI posture below avoids by making the app's label authoritative for domain rolls.
+
+---
+
+## Q3 — The Final Blow overrides; the rider rule is about riders
+
+**The question.** *The Final Blow* (Might Tier 3, once per session): spend a Spark on a Combat roll, succeed, and the target "is removed from the conflict entirely — defeated, fled, or broken — regardless of any remaining resources or abilities they had" (II.4a:93–97). III.3:140 states absolutely: "Riders never defeat an enemy on their own — Resolve does that." Which sentence wins?
+
+### Options considered
+
+- **(a) Full override.** The removal is real, Resolve notwithstanding, against any target.
+- **(b) Subordinate to the rider rule.** The Technique cannot remove a target with Resolve remaining.
+- **(c) Boss carve-out.** Overrides against Mooks and Named NPCs; against a Boss it instead depletes Resolve to the next phase threshold, or by some large fixed amount.
+
+### Selected: (a)
+
+**Default.** *The Final Blow* is not a rider and is not governed by the rider rule. III.3:140 constrains **rider Conditions** — the free Tier 1/Tier 2 hitchhikers on a 10+ Strike — and remains absolutely true as written: a rider still never defeats. *The Final Blow* is a Technique whose entire effect is a licensed exception to Resolve depletion, and its `Normal:` field already marks the departure ("A Strike depletes Resolve, and riders never defeat an enemy on their own," II.4a:99). It works on any target, Bosses included: that is what a Tier 3 capstone is for, and the adventure register wants the payoff to be real when it lands. **No body text in III.3 changes.** The system's existing costs are the balance: Tier 3 gating, once per session, a Spark spent, a Combat roll that must succeed at whatever difficulty the fiction sets — an MM facing a fresh Boss will rightly be calling that roll Hard.
+
+**Precision (Planner to word into the entry):** "succeed" means 7+. On a 7–9 the removal still happens — the partial's cost shapes the aftermath (what the removal costs, what it looks like, what it stirs up), never the removal itself. The three printed removal shapes — defeated, fled, or broken — are narrated under the table's usual division of labor and register: the blow is the player's, the aftermath is the MM's.
+
+**Guardrail.** Once per session, one target, *this* conflict — all already printed. Plus one MM1 design note: build Boss encounters so that the party deleting the Boss is a *win*, not a broken script — phase material is forfeit the moment a capstone lands, and an encounter that cannot survive its Boss's early exit was over-scripted by MM3's own standards.
+
+### Why (a)
+
+1. **(b) makes the Technique a trap option.** Subordinated to the rider rule, *The Final Blow* does nothing a successful Strike doesn't already do — a once-per-session Tier 3 capstone with zero effect. Printing a dead capstone is the single worst outcome for the players-feel-competent pillar.
+2. **(c) is arithmetic bolted to the game's most cinematic moment.** "Deplete to the phase threshold" requires the MM to consult a hidden number and announce a diminished result at the exact beat the table is leaning in. It converts a capstone into an asterisk. The protections it buys already exist as costs (above).
+3. **The absolutist sentence survives untouched.** The clean doctrine — *the rider rule governs riders; Techniques that override a baseline say so in their own text, and their `Normal:` field marks it* — resolves the collision with zero churn to III.3, MM1, MM5, or the Glossary, all of which keep their "riders never defeat" lines truthfully. This is also the template Pinnacle Techniques will need: overrides are explicit, costed, frequency-capped, and marked at the site of the exception.
+
+### Downstream robustness (Q3)
+
+- **Simulation corpus: intact, with the same honesty note as Q1.** `standard_party()` carries no Techniques; Series 7's Guardian gate and Series 9's recipes are calibrated for baseline parties and remain valid as published. A Tier 3 party with *The Final Blow* deletes roughly one Named/Boss actor per session — and Series 9 proved actor count *is* the difficulty dial — so the MM1 advisory sentence ("recipes are calibrated for baseline parties; step-easier Strike Techniques and Tier 3 capstones run the table about a band hot") covers Q1 and Q3 in one line.
+- **Engine invariant (P11):** every `resolve_current` mutation routes through `phase_crossed`. A Final Blow removal must therefore be implemented as an explicit **defeat event** through the canonical defeat path — never a `resolve_current = 0` write — so phase logic, logging, and any future sim series stay coherent, and capstone removals are distinguishable in transcripts.
+- **More content:** future capstones inherit the doctrine, not the exception — each new override is licensed by its own entry and marked in its own `Normal:` field. Nothing accumulates.
+- **If a table house-rules it away:** running (b) merely wastes one Technique slot at that table; nothing else depends on the override existing. Cheap to ignore, which is the right failure mode for a capstone.
+
+---
+
+## Implementation posture (direction, not tasks)
+
+**Shared principle:** the engine keeps its current shape — the MM chooses a difficulty label; the engine never computes situational difficulty (escalation fact 2). What changes is that **character-side steps become data the digital layer can apply silently after the MM's label**, which is the bookkeeping-absorption lever working as designed.
+
+- **Q1 — engine-assisted, MM-authoritative.** Add machine-readable step metadata to Technique definitions in `facet.yaml` (a `difficulty_step: easier` field plus an applicability descriptor). Mechanically-scoped Techniques (*Weapon Mastery*'s weapon type, *Steady Hand*, *Acclimated*'s hardship type, *Field of Mastery*'s field) can be auto-suggested by the client when their trigger data matches; fiction-scoped ones (*The Uncanny Angle*, *Pressure Point*) are a one-tap player toggle the MM sees. The server applies the step through the existing `_step_difficulty_easier` (engine.py:386) *after* the MM's label and **enforces the non-stacking guardrail** (at most one character-side step per roll). The roll banner shows both moves: "Hard (MM) → Standard (Weapon Mastery)." Prose home for the rule: III.1 *Difficulty* (the one legislative paragraph); III.3's Strike difficulty note and MM5 compress it per the quick-reference iron law.
+- **Q2 — already engine-enforced; ratify and pin.** No engine change. Add tests pinning the two behaviors as canon (ascendant → Broad table, no step; secondary → own table, one step). One-sentence wording fix in II.4b, II.4c, both `facet.yaml` technique roll-texts, and MM5:258 ("harder than normal for that domain"), all in the same commit per the sync iron law.
+- **Q3 — engine-enforced event, MM-confirmed in UI.** Mark the Technique in `facet.yaml` (an explicit override flag on the definition). The app offers the once-per-session action, tracks its use, requires MM confirmation, and resolves it as a defeat event through the canonical defeat path (P11 invariant). MM1 gets the encounter-design note and the shared calibration sentence.
+
+## Constraints and open questions handed to Planner
+
+1. **One legislative home per rule** (style law 2): Q1's composition paragraph lives in III.1 *Difficulty*; every quick ref that touches difficulty (III.3:128 area, MM5) compresses it in the same commit, per the "compressions, not paraphrases" iron law.
+2. **The MM1 calibration sentence** (Q1+Q3 shared) is advisory prose, not a Recipe Table change. The corpus and the table stand as published; do not re-run Series 7/9 for these rulings. An *optional* Series 10 (baseline party + step-easier Strikes + capstone, to quantify "a band hot") is sanctioned if Planner wants the number, but nothing gates on it.
+3. **Q2's wording fix touches five surfaces** (II.4b, II.4c, facet.yaml ×2 roll-texts, MM5:258) — one Worker task, one commit.
+4. **Q3's entry gains the 7+ precision sentence**; check the `Normal:` field still reads true afterward. No III.3 change.
+5. **Sim boundary reminder:** any Series 10 party flag must drive `combat.py` difficulty stepping through the shared module — the simulator may not carry its own copy of the Q1 guardrail.
+6. **Open question (non-blocking, user's taste, surfaced not decided):** whether the client should *auto-apply* mechanically-scoped Technique steps by default or always require the one-tap confirm. Both respect the ruling; it is a UX-trust question about how much the app decides silently. Default to one-tap confirm until the user weighs in.
+
+**Resolved. Return to Planner to continue from `docs/LOG_style_audit.md`: the three `Normal:`-pass open questions (Q1–Q3), now ruled; plan the prose, yaml, engine, and test tasks per the implementation posture above.**

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -515,3 +515,115 @@ behavioral upside, since Technique ids are looked up per-branch and never collid
 
 **Ruling: accepted as-is.** The asymmetric naming is cosmetic, not functional — both Techniques
 resolve correctly within their own Facet tree. No fix needed this cycle.
+
+---
+
+### B4 — Technique difficulty composes; the app applies mechanically-scoped steps automatically *(Brain ruling on the style-audit escalation, 2026-08-02; user ruling on the UX question, same day)*
+
+**Source:** `docs/BRIEF_technique_difficulty.md`, escalated from `docs/LOG_style_audit.md`
+after the `Normal:` pass found three baselines that did not exist.
+
+**Decision — three rulings and one UX call:**
+
+1. **Q1. Technique difficulty steps compose with the MM's situational call**, in a
+   fixed order: the MM declares the situational label per III.1, then any
+   character-side "one step easier" effect applies to that label, then the
+   four-rung ladder clamps. **Guardrail:** character-side steps never stack with
+   each other — at most one per roll, whatever its source.
+2. **Q2. The Second Domain penalty rides the grant route, not the domain count.**
+   Ascendant Domain's prismatic territory prices off the Broad table alone. The
+   Second Domain penalty is one step harder *than normal for that domain*, not
+   than the primary domain.
+3. **Q3. *The Final Blow* is a licensed override, not a rider.** III.3's "riders
+   never defeat" governs rider Conditions and stays verbatim. The removal works on
+   any target including Bosses, and is implemented as a **defeat event** through
+   the canonical path — never a raw `resolve_current` write (P11 invariant).
+4. **UX. Mechanically-scoped Technique steps auto-apply.** Where the trigger is
+   data the app already holds — *Weapon Mastery*'s weapon type, *Acclimated*'s
+   hardship type, *Field of Mastery*'s field, *Steady Hand*'s Finesse rolls — the
+   server applies the step without asking, and the roll banner shows both moves
+   ("Hard (MM) → Standard (Weapon Mastery)"). Fiction-scoped Techniques remain a
+   player toggle, because their trigger is a judgement call and no data the app
+   holds can settle it. **Only *The Uncanny Angle* ships as a toggle.**
+   *Pressure Point* was deferred entirely — it is party-wide scene state, not
+   roll-time metadata, and needs a store the app does not have (DESIGN §2.5,
+   `docs/TODO.md` T7). Five Techniques carry a step, not six.
+
+   Two Techniques the book scopes to one skill — *Acclimated* ("Endurance rolls
+   against your chosen hardship") and *Field of Mastery* ("Lore rolls that fall
+   within your chosen field") — carry a `requires_skill` conjunct. Without it the
+   engine implemented a wider rule than the printed one; caught in review, fixed
+   before merge.
+
+**Why:** the full argument is in the BRIEF. The load-bearing points:
+
+- Q1 was **already ruled in print** and never stated as a rule: III.3:513's play
+  example reads "Standard difficulty, but Weapon Mastery makes this one step
+  easier, so Easy" — the Technique applied *after* the base was set. The ruling
+  ratifies existing text rather than choosing against it. The non-stacking
+  guardrail is the exact shape of two guardrails already in canon (III.3:175,
+  III.3:410), so it costs no new concept.
+- Q2 ratifies working, tested code (`character.py:406–410`, `engine.py:330–338`),
+  which keeps the two grant routes apart *because the routes cost differently*.
+  The alternative prices a prismatic cantrip like the hardest acts in the game.
+- Q3's alternative makes a once-per-session Tier 3 capstone do nothing a
+  successful Strike does not already do.
+- Auto-apply is the bookkeeping-absorption pillar doing its job. A step the app
+  can derive from `technique_choices` is a step no human should be asked to
+  remember mid-exchange, and the banner keeps it visible rather than silent.
+
+**Rejected:**
+
+- *Q1, inside the budget* — makes Tier 1 signatures evaporate whenever the MM
+  applies any hardship, so a Technique's value would depend on the difficulty call.
+- *Q1, free composition* — arithmetic at the table, and it compounds with every
+  Facet shipped. The guardrail caps total drift at one rung forever.
+- *Q3, Boss carve-out* — requires the MM to consult a hidden number and announce a
+  diminished result at the most cinematic beat in the game.
+- *One-tap confirm for every step* — rejected by the user in favour of auto-apply.
+  The confirm survives only where the trigger is genuinely fictional.
+
+**Latent defect fixed in the same ruling:** *Second Domain* reads "one difficulty
+step harder **than your primary domain**." Read literally, a Focused-primary
+caster's second standard domain prices at Focused-plus-one — which *is* the
+standard table, silently deleting the penalty. Five surfaces re-anchor to "harder
+than normal for that domain": II.4b, II.4c, `facet.yaml` ×2 roll-texts, MM5.
+
+**Corpus:** intact for all three. `standard_party()` carries no Techniques
+(`combat_sim.py:973–981`), so Series 7 and 9 stand as published. MM1 gains one
+advisory sentence; no re-run gated.
+
+**Status:** ✅ Resolved by Brain, UX resolved by the user. Planner has produced
+`docs/DESIGN_technique_difficulty.md` and `docs/TASKS_technique_difficulty.md`.
+Return to Worker at TD-1.
+
+---
+
+### B5 — The Strike's skill is a default, not a restriction *(ratified 2026-08-03, backfilled)*
+
+**Decision:** III.3 names **Combat** for melee and unarmed Strikes and **Finesse**
+for ranged ones as *defaults*, not restrictions. Where the fiction supports it, a
+player may Strike with the skill that describes what they are doing, and where two
+pairings both fit, the player chooses. The MM may name a different attribute where
+the fiction clearly supports one.
+
+**Why:** the engine has always accepted any attribute/skill pairing the client
+sends (`_handle_strike`). The book said the skill *is* Combat or Finesse, which
+read as a restriction the engine does not enforce — and which made a
+Finesse-based unarmed character, exactly the monk-adjacent build Zulnut is,
+unbuildable by the book while being buildable in the app.
+
+Found by an agentic playtest on 2026-07-31
+(`playtest/08_npc_variance/subagent_session/report.md`, finding F1) when a
+monk-adjacent PC struck with Dexterity + Finesse, the engine allowed it, and the
+book forbade it.
+
+**Status:** ✅ Landed with the style-audit commit and pinned by **INV-8**
+(`test_books_do_not_restrict_the_strike_pairing`), which fails if any book line
+states the pairing without hedging.
+
+**Backfilled.** This entry is written after the fact. The ruling was recorded in
+the INV-8 test docstring and the playtest report but never in `DECISIONS.md`,
+which is where a rules change belongs — a reviewer reading only the decision log
+would have found a rules change with no ruling behind it. Recording the gap
+rather than quietly closing it.

--- a/docs/DESIGN_technique_difficulty.md
+++ b/docs/DESIGN_technique_difficulty.md
@@ -1,0 +1,311 @@
+# DESIGN — Technique difficulty, domain pricing, and licensed overrides
+
+**Tier:** Planner. **Input:** `docs/BRIEF_technique_difficulty.md` (Brain, 2026-08-02)
+and the user's UX ruling of the same day. **Decision record:** `docs/DECISIONS.md` B4.
+**Tasks:** `docs/TASKS_technique_difficulty.md`.
+
+---
+
+## 1. Scope
+
+Three rulings to land, in one cycle, because they were escalated together and share
+one mechanism:
+
+| | Ruling | Where the work is |
+|---|---|---|
+| **Q1** | Technique difficulty steps compose with the MM's call; at most one character-side step per roll | schema, `combat.py`, three WS handlers, client, prose |
+| **Q2** | Second Domain prices off its own domain's table; Ascendant prices off Broad alone | prose ×5 surfaces, tests only — **no engine change** |
+| **Q3** | *The Final Blow* is a licensed override, resolved as a defeat event | schema, engine, WS handler, client, MM1 note |
+
+**Non-goals this cycle.** No re-run of Series 7/9 (B4: corpus intact). No change to
+III.3's rider sentence. No new difficulty rungs. No change to how the MM declares a
+label — the MM stays authoritative for the *situational* call, and always will.
+
+---
+
+## 2. The mechanism (Q1)
+
+### 2.1 Where the rule lives
+
+**`software/app/game/combat.py`.** Non-negotiable: the project's iron law is that
+the simulator may only drive `combat.py` and must never re-implement a rule
+(`CLAUDE.md`). Difficulty composition is a rule. It goes in the shared module, and
+the WS handlers and any future sim series both call it.
+
+`engine.py` keeps `_step_difficulty_easier` / `_harder` — those are ladder
+primitives, not the rule. `combat.py` composes them.
+
+### 2.2 The function
+
+```
+apply_character_difficulty_step(
+    declared_label, character, context, ruleset
+) -> (final_label, applied_technique_id | None)
+```
+
+- `declared_label` is the MM's situational call, already resolved (including
+  set-to-label effects like a Tier 2 rider making a target Easy). The function
+  never second-guesses it.
+- `context` is a small dict of roll facts the app already holds or newly sends:
+  `skill_id`, `weapon_category`, `hazard_type`, `knowledge_field`, and
+  `declared_technique_ids` (the player's toggles).
+- Returns the stepped label **and which Technique did it**, because the roll banner
+  has to show both moves and the transcript has to be auditable.
+
+**Order:** declared label first, character step second, ladder clamps. **Guardrail:**
+at most one character-side step per roll. If several qualify, the function picks
+deterministically — a player-declared Technique wins over an auto one, then lowest
+`id` — and reports the one it used. Determinism matters more than cleverness here:
+two Techniques that both apply produce the same label either way (one step), so the
+only thing the choice affects is what the banner names, and a stable answer is
+easier to test and to explain at a table.
+
+### 2.3 Applicability: two trigger kinds
+
+New `TechniqueDef` fields, both optional so every existing Technique is unaffected:
+
+- `difficulty_step: "easier" | "harder" | null`
+- `step_trigger:` one of
+  - `{kind: "auto", match: <field>, against: "choice" | <literal>}` — the app
+    evaluates it from data it holds. Per B4's UX ruling, these apply **without
+    asking**.
+  - `{kind: "declared"}` — the player toggles it on the roll, because the trigger
+    is a judgement no data settles.
+
+Assignments for this cycle:
+
+| Technique | Step | Trigger |
+|---|---|---|
+| *Weapon Mastery* | easier | auto — `weapon_type` == `technique_choices["weapon_mastery"]` — see §8, this started as `weapon_category` and was wrong |
+| *Acclimated* | easier | auto — `hazard_type` == `technique_choices["acclimated"]`, **and** `skill_id == endurance` |
+| *Field of Mastery* | easier | auto — `knowledge_field` == `technique_choices["field_of_mastery"]`, **and** `skill_id == lore` |
+| *Steady Hand* | easier | auto — `skill_id` == `finesse` |
+| *The Uncanny Angle* | easier | declared |
+| *Pressure Point* | — | **out of scope this cycle** (see §2.5) |
+
+**On *Steady Hand*.** Its printed trigger is "precision work under pressure",
+which is fiction. `skill_id == finesse` is a proxy, and a slightly generous one —
+not every Finesse roll is precision under pressure. Planner's call: take the
+generous reading. The alternative is a toggle on the commonest skill in the game,
+which is friction on every roll to save the MM from a step the guardrail already
+caps at one rung. If play shows it firing where it should not, the MM's lever is
+the situational label, which is one step in the other direction and already exists.
+
+### 2.4 The new data the app must carry
+
+`weapon_category` does not exist anywhere today — not on `Character`, not in the
+strike message, not in `play.js` (`inventory` is `list[str]` free text). It must be
+added to the strike message, sourced from a picker in the strike UI listing the five
+IV.1 categories.
+
+Side benefit worth taking: IV.1 already says a weapon's category **sets the Strike
+attribute**. The category picker can drive the attribute selection, which removes a
+step the player currently does by hand. That is a UX improvement, not scope creep —
+it is the same picker.
+
+`hazard_type` and `knowledge_field` are similarly new but cheaper: both are optional
+strings on the generic-roll message, set by the MM or player when relevant, absent
+otherwise. An absent field simply means the auto trigger does not fire.
+
+### 2.5 *Pressure Point* is deferred, deliberately
+
+*Pressure Point* is not a self-buff. It makes a difficulty one step easier **for any
+character who follows the instructions, for the rest of the scene** — party-wide,
+scene-scoped state, not roll-time metadata. It needs a scene-effect store the app
+does not have.
+
+Deferring it is honest and keeps this cycle atomic. Until it lands, it stays
+MM-applied: the MM lowers the label, exactly as today. **The guardrail must be
+documented at the point of the MM's call** so an MM applying Pressure Point by hand
+and a Technique auto-applying do not both land on the same roll. That documentation
+is a task, not a nice-to-have.
+
+Follow-up recorded in `docs/TODO.md`.
+
+### 2.6 Which handlers call it
+
+Three call sites, all in `websocket.py`, all after the label is known and before
+`RollRequest` is built: the **strike** handler (~585), the **generic roll** handler
+(~275/310), and the **reaction** handler (~1111). The magic handler (~950) is
+excluded — magic difficulty comes from the domain/scope table, and no Technique in
+this cycle steps it.
+
+### 2.7 What the client shows
+
+The roll banner shows both moves: `Hard (MM) → Standard (Weapon Mastery)`. This is
+the whole reason auto-apply is acceptable rather than spooky. A step nobody sees is
+a step nobody trusts; the banner is what makes the automation legible, and it is a
+required part of the feature, not a polish item.
+
+---
+
+## 3. Q2 — pricing, and the wording defect
+
+**No engine change.** `character.py:406–410` and `engine.py:330–338` already
+implement the ruling; the work is to make canon say what the code does, and to pin
+it so a future refactor cannot quietly reverse it.
+
+**The defect.** *Second Domain* reads "one difficulty step harder **than your primary
+domain**". For a Focused-primary caster, Focused-plus-one *is* the standard table —
+the penalty silently vanishes. Five surfaces re-anchor to **"one difficulty step
+harder than normal for that domain"**:
+
+`II.4b_...Mind.md` · `II.4c_...Soul.md` · `facet.yaml` (`second_domain_mind.roll`,
+`second_domain.roll`) · `MM5_Quick_Reference.md`.
+
+All five in one commit, per the sync iron law. `II.4b`/`II.4c` bodies are
+hand-written; the `Normal:` fields already read correctly and need no change.
+
+**Tests to add** (they are the deliverable — the prose is a consequence):
+one pinning Ascendant → Broad table with no step, one pinning Second Domain → own
+table, one step, and one specifically covering the Focused-primary case the old
+wording broke.
+
+---
+
+## 4. Q3 — the licensed override
+
+**Data.** `TechniqueDef` gains `removes_target_from_conflict: bool`, set true for
+`the_final_blow` only. A flag, not a mechanism — the point is that overrides are
+explicit at the site of the exception and greppable.
+
+**Engine.** A new `combat.py` function that resolves the removal as a **defeat
+event**, routed through the same path a Resolve-0 defeat takes. It must never write
+`resolve_current = 0` directly — P11's invariant is that every `resolve_current`
+mutation routes through `phase_crossed`, and a raw write would skip phase logic and
+corrupt transcripts. The removal must also be distinguishable in the transcript
+from an ordinary defeat, so a future sim series can count capstone removals.
+
+**Frequency.** `Character.techniques_used_this_session` already exists and is the
+right store. No new field.
+
+**Flow.** Player declares Final Blow with their Strike → Spark spent, Combat roll
+resolved → **on 7+** (both success tiers, per the brief) the target is removed →
+MM confirmation required before the removal commits, because it deletes an actor
+from the MM's encounter. Auto-apply governs *difficulty steps*, not actor removal;
+these are different questions and the user answered the first.
+
+**Prose.** II.4a's entry gains one precision sentence (7+ is a success; the
+partial's cost shapes the aftermath, never the removal). III.3 changes **not at
+all** — that is the point of the ruling. MM1 gains the encounter-design note.
+
+---
+
+## 5. Testing strategy
+
+TDD, per the project ethos: test first, red, implement, green. Minimum three tests
+per new public function (happy path, edge, error).
+
+**The edges that actually matter here** — write these before the implementation:
+
+1. **Clamping.** A step easier from Easy stays Easy. A step must never produce a
+   label outside the four-rung ladder.
+2. **The guardrail.** Two qualifying Techniques on one roll produce **one** step,
+   and the reported technique id is deterministic.
+3. **Non-firing.** Weapon Mastery (blades) with `weapon_category: "unarmed"` does
+   not fire. An absent `weapon_category` does not fire. A Technique the character
+   has not unlocked does not fire.
+4. **Order.** The MM's Hard plus a Technique step yields Standard, not Easy —
+   proving the step composes with the call rather than replacing it.
+5. **Precedence.** A declared toggle beats an auto match, and the banner names the
+   one that applied.
+6. **Q3 invariant.** A Final Blow removal produces a defeat event and routes
+   through `phase_crossed`; no test may observe a raw `resolve_current` write.
+7. **Sim boundary.** A test asserting the simulator calls the shared composition
+   function rather than carrying its own copy — the regression that invalidated a
+   corpus once already.
+
+**Docs invariants.** INV-14 already pins every Technique's `use`/`normal` and its
+header against `facet.yaml`; the new fields must not break it. The Q2 wording fix
+touches MM5, so INV-6 (typographic dashes) and the quick-ref compression law apply.
+
+---
+
+## 6. Sequencing
+
+TD-1 → TD-3 are Q2: prose and tests only, no engine, and they close a live defect.
+Do them first — they are independent of everything else and lowest risk.
+
+TD-4 → TD-11 are Q1, in dependency order: schema, then the shared rule, then data
+plumbing, then handlers, then client, then prose.
+
+TD-12 → TD-15 are Q3.
+
+TD-16 is the MM1 calibration sentence, shared by Q1 and Q3, and lands last because
+it describes the finished behaviour.
+
+---
+
+## 7. Open questions handed to Worker
+
+None blocking. Two things a Worker should escalate rather than decide:
+
+1. If `skill_id == finesse` proves too broad for *Steady Hand* during
+   implementation — e.g. it fires on ranged Strikes, which are Finesse — escalate
+   rather than inventing a narrower predicate. The Strike case is real and §2.3's
+   generous reading may need a carve-out.
+2. If routing the Q3 removal through the canonical defeat path turns out to
+   require changing that path's signature, stop. That path is P11-invariant
+   territory and a signature change is a Planner decision.
+
+---
+
+## 8. Amendment — the two weapon vocabularies *(Planner, 2026-08-02)*
+
+**Raised by:** Worker escalation during TD-7 (`docs/LOG_technique_difficulty.md`).
+**Cause:** a Planner error in §2.3/§2.4. TD-7 was specified against IV.1's weapon
+*categories* without checking what *Weapon Mastery* actually asks the player to
+choose. It asks for something else.
+
+### The finding
+
+Two vocabularies exist and they are **not** the same list:
+
+| | Values | Job |
+|---|---|---|
+| `weapon_category` (IV.1, `facet.yaml equipment.weapon_categories`) | heavy · standard · light · ranged · unarmed | **Mechanical** — sets which attribute a Strike uses |
+| *Weapon Mastery*'s choice (II.4a, `choice_prompt`) | blades · blunt · polearms · unarmed | **Shape** — what the character has mastered |
+
+Only `unarmed` appears in both. As shipped, *Weapon Mastery* can auto-fire for one
+of its four choices, and the case B4 cites as its flagship justification — Mordai
+with Weapon Mastery (blades), III.3:513 — can never fire at all.
+
+### The ruling: they are orthogonal axes, and both stay
+
+A longsword is `standard` category **and** `blades` type. A greatsword is `heavy`
+**and** `blades`. The lists cut across each other, so collapsing them breaks one job
+or the other:
+
+- Retiring `blades/blunt/polearms` and re-anchoring Weapon Mastery to the
+  mechanical categories would make "Weapon Mastery (standard)" the printed choice —
+  mastery of a *stat bucket* rather than of a kind of weapon. Rejected: it reads as
+  a spreadsheet and it silently changes what the Technique means.
+- Retiring the categories would take the attribute default with them. Rejected.
+
+**So:** the Strike message carries **both**. `weapon_category` keeps its TD-7 job
+(defaulting the attribute). A new `weapon_type` — blades · blunt · polearms ·
+unarmed — carries shape, and *Weapon Mastery*'s `step_trigger.match` retargets to
+it. Both stay optional; absent means the trigger does not fire.
+
+### Second finding: there is no choice picker
+
+`builder.js::pickTechniqueChoice` only knows how to build **domain** lists. For
+*Weapon Mastery*, *Acclimated*, and *Field of Mastery* it produces an empty option
+set, so those choices cannot currently be made in the app at all — which means the
+`against: "choice"` triggers have nothing to match even once the vocabulary is fixed.
+
+**Fix:** `TechniqueDef` gains `choices: list[str] | None`. The three choice-bearing
+non-domain Techniques enumerate their options as data instead of burying them in
+`choice_prompt` prose, and the builder renders a picker from it. `choice_prompt`
+stays as the human-readable label.
+
+### Content gap — not fixed here, referred to the user
+
+*Weapon Mastery*'s four types have **no option covering ranged weapons**. An archer
+cannot meaningfully take the Technique. That is canon as printed in II.4a, not a
+defect this cycle introduced, and adding a fifth option is a content decision for
+the setting's author. Recorded in `docs/TODO.md`; do not fix it in code.
+
+### Tasks
+
+TD-18 through TD-20, below.

--- a/docs/LOG_technique_difficulty.md
+++ b/docs/LOG_technique_difficulty.md
@@ -1,0 +1,771 @@
+# LOG — Technique difficulty, domain pricing, and licensed overrides
+
+**Tier:** Worker (Sonnet) execution log
+**Design:** `docs/DESIGN_technique_difficulty.md` · **Tasks:** `docs/TASKS_technique_difficulty.md`
+**Ruling:** `docs/DECISIONS.md` B4
+
+---
+
+## Q2 — pricing and the wording defect (TD-1, TD-2, TD-3)
+
+**Date:** 2026-08-02
+**Scope:** the Q2 block only, per assignment — TD-1 through TD-3. TD-4 onward (Q1's
+composition mechanism, Q3's licensed override) are untouched by this pass.
+
+### The defect
+
+*Second Domain* (Soul Communion Tier 3, and Mind Archive Tier 3's mirror) read "one
+difficulty step harder **than your primary domain**" across five surfaces. Read
+literally, this anchors the penalty to the *caster's other domain's table*, not to
+the *granted domain's own table*. For a Standard- or Broad-primary caster these
+usually coincide, which is exactly why the defect went unnoticed. It only bites a
+**Focused-primary caster**: Focused's table is Easy/Standard/Hard; stepping *that*
+table one notch from its minor-scope value (Easy) lands on Standard — which is the
+granted domain's own *unstepped* minor value if the grant is a Standard-type domain.
+The penalty silently evaporates.
+
+B4 ruled the correct anchor is "one difficulty step harder **than normal for that
+domain**" — the grant's own domain-type table, stepped once. B4 also established
+that `character.py:406–410` and `engine.py:330–338` already implement this correctly;
+only the prose (and one `roll:`/`description:` pair per Facet in `facet.yaml`) said
+the wrong thing.
+
+### TD-1 — Pin the two domain grant routes
+
+Added three tests to `software/tests/test_ascendant_domain.py`, all passing against
+the **unmodified engine** — no engine changes were made, per the task's explicit
+trap-avoidance instruction. This confirms B4's premise: the engine already
+implements Q2 correctly, and only the wording needed fixing.
+
+- `test_b4q2_ascendant_domain_prices_off_broad_table_no_step` (parametrized over
+  minor/significant/major) — Ascendant Domain's prismatic territory (Chronomancy,
+  Broad) resolves to Hard / Very Hard / Very Hard at all three scopes, with no
+  extra character-side step layered on top of the Broad table.
+- `test_b4q2_second_domain_prices_off_own_table_one_step_harder` — a Focused-primary
+  Soul mage (Fire) taking Second Domain (Storm, Standard) resolves Storm/minor to
+  Hard — Standard's own minor value (Standard) stepped once, not Fire's Focused
+  table stepped once (which would give Standard, not Hard).
+- `test_b4q2_second_domain_focused_primary_does_not_leak_into_pricing` — the case
+  the retired wording broke, made explicit: a Focused-primary Mind mage
+  (Inscription) taking Second Domain (Illusion, Standard) resolves Illusion/minor
+  to **Hard**, and the test explicitly asserts it is *not* **Standard** — the value
+  the literal "harder than your primary domain" reading would have produced
+  (Focused-minor = Easy, stepped once = Standard).
+
+All three ran green on the first pass; no escalation was needed.
+
+Ran `pytest tests/test_ascendant_domain.py -q` afterward: 45 passed (42 pre-existing
++ 3 new — the file already carried adjacent coverage for the Broad table and the
+one-step tax individually; these three are the dedicated B4 Q2 pin naming the
+defect explicitly, including the previously-uncovered Focused-primary contrast).
+
+### TD-2 — Re-anchor the Second Domain wording on five surfaces
+
+One pass, all five surfaces, matching string replaced everywhere it appeared
+(`"harder than your primary domain"` → `"harder than normal for that domain"`):
+
+1. `player_handbook/II.4b_Character_Creation_Facet_Mind.md` — the `**Roll:**` line
+   and the body-prose sentence for *Second Domain* (Archive, Tier 3).
+2. `player_handbook/II.4c_Character_Creation_Facet_Soul.md` — same two spots for
+   *Second Domain* (Communion, Tier 3).
+3. `software/facets/base/facet.yaml` — `second_domain_mind`'s `description` and
+   `roll` fields.
+4. `software/facets/base/facet.yaml` — `second_domain`'s `description` and `roll`
+   fields (the task named only the two `roll:` strings explicitly, but the
+   `description:` prose carried the identical defect and was fixed in the same
+   pass — the acceptance grep is on the string, not the field name, and a
+   `description:` left unfixed would still fail it).
+5. `mm_manual/MM5_Quick_Reference.md` — the Second Domain compression line. This one
+   didn't carry the *exact* retired phrase ("...harder than **the primary**", not
+   "...your primary domain") but stated the same wrong anchor and was re-anchored
+   to match.
+
+`Normal:` fields were not touched, per the task — they already read correctly.
+
+**Regression test added:** `test_second_domain_wording_does_not_anchor_on_primary_domain`
+in `software/tests/test_docs_consistency.py`, scanning every book file plus
+`facet.yaml` for the retired string.
+
+**Verification:**
+- `grep -rn "harder than your primary domain" player_handbook/ mm_manual/ software/facets/base/facet.yaml`
+  → no matches (the only remaining repo-wide hit is the task file itself, quoting
+  the grep command).
+- `pytest tests/test_docs_consistency.py -q` → 31 passed, including INV-6
+  (`test_mm5_uses_typographic_dashes`) and INV-14 (`test_every_technique_has_use_and_normal_in_facet_yaml`,
+  `test_every_technique_entry_states_branch_tier_and_attribute`,
+  `test_technique_headers_match_facet_yaml`, `test_every_technique_entry_carries_a_normal_line`).
+- `pytest tests/test_ascendant_domain.py -k b4q2 -v` → still 5 passed after the
+  prose edits (TD-1's pin is unaffected by a wording-only change, as expected).
+
+One incidental bug caught and fixed during this task: my first edit to
+`test_docs_consistency.py` appended the new test function in a way that orphaned
+the previous test's trailing `assert not problems, ...` line outside its own
+function body (a `NameError: name 'problems' is not defined` inside the *new*
+test). Caught immediately by running the suite before moving on; fixed by moving
+the assert back into `test_every_bestiary_creature_has_a_lore_box`, its rightful
+owner. Not a design defect — a self-inflicted edit-tool slip, corrected before
+this log entry was written.
+
+### TD-3 — this entry
+
+Log created. Q2 tests named above: `test_b4q2_ascendant_domain_prices_off_broad_table_no_step`,
+`test_b4q2_second_domain_prices_off_own_table_one_step_harder`,
+`test_b4q2_second_domain_focused_primary_does_not_leak_into_pricing`.
+
+### Status
+
+TD-1, TD-2, TD-3 done. TD-4 (Q1 schema work) and beyond are **not started** —
+out of scope for this assignment. `docs/TASKS_technique_difficulty.md`'s progress
+table updated accordingly.
+
+Full suite run from `software/`: **`python3 -m pytest -q`** — see the parent
+session's report for the final pass/fail count (this log was written before that
+run completed; the count is not fabricated here).
+
+---
+
+## Q1 wiring — TD-7 through TD-11
+
+**Date:** 2026-08-02
+**Scope:** TD-7 (weapon_category on the Strike), TD-8 (hazard_type/knowledge_field
+on the generic roll), TD-9 (wire the three handlers to
+`combat.apply_character_difficulty_step`), TD-10 (the roll banner), TD-11
+(III.1 legislation + III.3/MM5/MM2 compression). TD-4–TD-6 (schema, the
+composition function, the five Techniques' metadata) were already done —
+built on, not redone. TD-12 and later (Q3, the licensed override) were not
+started, per assignment boundary.
+
+### TD-7 — `weapon_category` on the Strike
+
+`software/app/api/websocket.py::_handle_strike` accepts an optional
+`weapon_category` string. If present it is validated against
+`session.ruleset.equipment.weapon_categories` (the IV.1:13-19 reference table
+already in `facet.yaml` from an earlier, unrelated sync task — `EquipmentDef`,
+sync-M-12) and rejected with an error message if unrecognised; if absent the
+field is simply `None` downstream and nothing about the roll changes. Per
+INV-8 and the task's explicit instruction, this validation is against the
+five-category *vocabulary*, never against the attribute/skill pairing the
+client sends — the docstring on the validation block says so explicitly, and
+`test_strike_with_dexterity_attribute` / `test_strike_with_intelligence`
+(pre-existing) still pass unmodified, proving no new gate reached the
+attribute check.
+
+Client side (`index.html`, `play.js`): a `#strike-weapon-category` select
+listing the five IV.1 categories, wired to a new `onStrikeWeaponCategoryChange()`
+that reads `state.ruleset.equipment.weapon_categories[category].attributes[0]`
+and sets `#strike-attribute` — the *default*, never a lock; the player can
+still change the attribute select afterward, and the server never checks that
+the two agree. This reads the attribute mapping from the ruleset at runtime
+rather than hardcoding a second copy of IV.1's table in JS.
+
+**Tests** (`software/tests/test_websocket.py`, class `TestCombatGameplayLoop`):
+`test_strike_without_weapon_category_behaves_as_today`,
+`test_strike_with_valid_weapon_category_round_trips`,
+`test_strike_with_unknown_weapon_category_returns_error`.
+
+### TD-8 — `hazard_type` / `knowledge_field` on the generic roll
+
+`_handle_roll` accepts both as optional strings, folded into the same
+composition context as `skill_id`. Absent means the corresponding auto
+trigger cannot fire — no error, no behaviour change from today.
+
+Client side: two optional text inputs on the Roll Dice card
+(`#play-roll-hazard-type`, `#play-roll-knowledge-field`), sent as `null` when
+blank. Added because without *some* way to set these, Acclimated and Field of
+Mastery could never fire outside a Strike — DESIGN §2.4 says they are "set by
+the MM or player when relevant," which presupposes a place to set them. Kept
+as free-text rather than a fixed dropdown because Acclimated's and Field of
+Mastery's `technique_choices` values are themselves free text chosen at
+Technique-select time (see the Escalation below for why that choice path is
+itself broken today).
+
+**Tests:** `test_roll_without_hazard_or_knowledge_field_behaves_as_today`,
+`test_roll_hazard_type_and_knowledge_field_round_trip_without_error` (class
+`TestWebSocketRoll`).
+
+### TD-9 — wiring the three handlers
+
+Added one shared wrapper, `_apply_difficulty_step(character, declared_difficulty,
+context, ruleset)`, in `websocket.py` — it calls
+`combat_module.apply_character_difficulty_step` (never re-derives a step) and
+only adds a display-name lookup so the broadcast payload can carry
+`{technique_id, technique_name, from, to}` for the banner. All three handlers
+call it after the declared label is known and before `RollRequest` is built,
+per DESIGN §2.6:
+
+- **Strike** (`_handle_strike`): context = `{skill_id, weapon_category,
+  declared_technique_ids}`.
+- **Generic roll** (`_handle_roll`): context = `{skill_id, hazard_type,
+  knowledge_field, declared_technique_ids}`.
+- **Reaction** (`_handle_react`): only Dodge/Parry roll at all; context =
+  `{skill_id, declared_technique_ids}` (`skill_id` is `"combat"` for Parry,
+  `None` for Dodge — Steady Hand's `skill_id == "finesse"` trigger structurally
+  cannot fire on either, which is correct: reactions aren't Finesse checks).
+  Absorb/Intercept never build a `RollRequest`, so `technique_step` is simply
+  `None` on their payload — the key is always present so the client never has
+  to special-case a missing key.
+
+The **magic handler is untouched** — confirmed by
+`test_cast_ignores_a_technique_that_would_fire_on_a_strike`, which gives the
+character an unlocked, matching-context Technique and asserts `cast_result`
+carries no `technique_step` key at all.
+
+**Tests:** `test_strike_weapon_mastery_steps_difficulty_when_matched`,
+`test_strike_weapon_mastery_does_not_fire_on_mismatch`,
+`test_roll_acclimated_steps_difficulty_when_hazard_matches`,
+`test_roll_field_of_mastery_does_not_fire_on_mismatched_field`,
+`test_react_declared_technique_steps_difficulty`,
+`test_react_technique_not_toggled_does_not_fire`,
+`test_react_absorb_carries_no_technique_step_key`,
+`test_cast_ignores_a_technique_that_would_fire_on_a_strike`.
+
+### TD-10 — the roll banner
+
+Broadcast payloads (`roll_result`, `strike_result`, `react_result`) all carry
+a `technique_step` key — `None` when nothing fired, otherwise `{technique_id,
+technique_name, from, to}`. `buildRollResultHtml` (`play.js`, shared by Roll
+and Strike results) renders a line reading `Hard (MM) → Standard (Weapon
+Mastery)` when `msg.technique_step` is present and renders nothing otherwise;
+`onReactResult` appends the same two moves to its chat line, since reactions
+have no result-box banner to hang it on. `onStrikeResult` had to be updated
+to actually forward `technique_step` into the object it hands to
+`showRollResultBox` — it builds a fresh `{player, character_name}` object
+rather than passing the whole `msg` through, and that reconstruction would
+silently have dropped the field.
+
+e2e tests use the same direct-`onStrikeResult`-injection pattern already
+established by `test_a_strike_on_a_tracked_enemy_can_be_applied_from_the_prompt`
+(pre-existing) rather than driving a full Technique-grant round trip through
+the advancement UI — that flow requires reaching a Facet-level threshold
+(5 rank advances) which is impractical to stage in a browser test, and this
+suite already has a precedent for testing pure client-rendering behaviour by
+calling the handler function directly with a synthetic payload.
+
+**Tests** (`software/tests/e2e/test_ui_flows.py`, class `TestCombatLoop`):
+`test_technique_step_banner_shows_both_moves`,
+`test_ordinary_strike_banner_has_no_technique_step`.
+
+### TD-11 — prose
+
+- **III.1 *Difficulty*** (the legislative home): one new paragraph after "The
+  MM declares difficulty before you roll," stating the fixed order (MM's call,
+  then at most one character-side step, then the ladder clamps) and the
+  auto/declared split, without naming implementation details (no "banner," no
+  "context dict" — "the roll result names it").
+- **III.3** *Strike*: one compressing sentence appended to the existing
+  difficulty paragraph — "A Technique may then move the MM's call one step
+  further, exactly as any roll's difficulty can (see *Difficulty*, III.1)."
+  The Weapon Mastery vignette (III.3:513, "Standard difficulty, but Weapon
+  Mastery makes this one step easier, so Easy") and the "riders never defeat"
+  sentence are both untouched — verified by not editing those lines and by
+  the full suite staying green.
+- **MM5**: one line under the Difficulty table, matching the manual's existing
+  "compressed from X — see X for full text" register without literally using
+  that phrase (short enough not to need it): "A Technique may then move your
+  call one step further — at most one per roll, auto-applied when its trigger
+  is data the app already holds, player-declared otherwise (see *Difficulty*,
+  III.1)."
+- **MM2**: new `### Difficulty and Technique Steps` subsection under
+  *Pacing Toolkit*, plus the DESIGN §2.5 guardrail as an **MM Note** box
+  ("Pressure Point does not stack with an auto-applied step") — the exact
+  point-of-the-MM's-call documentation DESIGN said was "a task, not a
+  nice-to-have."
+
+INV-9 through INV-14 all pass. `Index.md`, `List_of_Tables.md`,
+`List_of_Boxes.md` were regenerated (`python -m tools.build_index` then
+`python -m tools.build_table_register` then `build_index` again — the first
+`build_index` pass runs before the table/box registers reflect the new MM2
+box and briefly disagrees with itself; a second pass after
+`build_table_register` is required for both to agree, and is worth flagging
+for anyone who hits the same false failure) and are part of this commit's
+changes, not hand-edited.
+
+### Test count
+
+15 new tests: 3 (TD-7) + 2 (TD-8) + 8 (TD-9, includes the strike/roll cases
+that also serve TD-7/TD-8's "values reach the composition context" proof) +
+2 (TD-10, e2e). `python3 -m pytest -q` from `software/`: **1340 passed**
+(1325 baseline + 15), zero failures, zero skips beyond the suite's existing
+Playwright-conditional skip guard. Ran in the foreground, ~4m52s.
+
+## ESCALATION — Weapon Mastery's own choice vocabulary cannot fire through `weapon_category`
+
+**What was attempted:** TD-7 as specified — `weapon_category` on the wire is
+one of IV.1's five mechanical categories (`heavy`, `standard`, `light`,
+`ranged`, `unarmed`), sourced from `ruleset.equipment.weapon_categories`,
+matching DESIGN §2.4 ("sourced from a picker in the strike UI listing the
+five IV.1 categories") and TD-7's literal instruction.
+
+**What is wrong:** *Weapon Mastery*'s own `choice_prompt` — both in
+`facet.yaml` and in `player_handbook/II.4a_Character_Creation_Facet_Body.md:53`
+("Choose: A weapon type: blades, blunt, polearms, or unarmed.") — uses a
+**different, fictional taxonomy**, not IV.1's mechanical one. TD-6's
+`step_trigger` for `weapon_mastery` is `{match: weapon_category, against:
+choice}`, meaning it compares the wire's `weapon_category` against whatever
+string the player recorded in `technique_choices["weapon_mastery"]` at
+selection time — which, per the existing choice prompt, is one of `blades`,
+`blunt`, `polearms`, `unarmed`. Only `unarmed` overlaps with IV.1's five
+categories (`heavy`, `standard`, `light`, `ranged`, `unarmed`). A character
+who takes Weapon Mastery in blades, blunt, or polearms — three of the four
+choices — can **never** have it auto-fire, because a Strike's `weapon_category`
+will never equal `"blades"`.
+
+This is not a hypothetical edge case. It breaks the canonical example B4
+itself cites as ratifying Q1: III.3:513 — *"Mordai: 'I want to test it... I
+have Weapon Mastery in blades.' MM: 'Standard difficulty, but Weapon Mastery
+makes this one step easier, so Easy.'"* Under this cycle's implementation,
+Mordai's Strike would carry `weapon_category` in {`heavy`, `standard`,
+`light`, `ranged`, `unarmed`} (whatever the dagger/sword/etc. he is actually
+using resolves to under IV.1), which never equals his recorded choice
+`"blades"` — the auto-apply would silently **not fire**, and the MM would
+have to apply the step by hand, exactly as before B4. The two taxonomies are
+not just differently spelled — they are orthogonal: a greatsword is
+simultaneously `heavy` (IV.1, attribute-setting) and a `blade` (Weapon
+Mastery's own vocabulary), so there is no simple rename that reconciles them;
+a "blade" specialist should arguably fire regardless of whether the specific
+blade in hand is Light (dagger) or Heavy (greatsword).
+
+**A second, compounding defect found while investigating the first:**
+`builder.js::pickTechniqueChoice` — the only client code that prompts for a
+Technique's `choice` when `has_choice` is true — **only knows how to offer
+magic domain lists** (`magic.mind_domains` / `magic.soul_domains`). For a
+non-domain `has_choice` Technique like Weapon Mastery, Acclimated, or Field of
+Mastery, it computes `facetForDomains = def.requires_domain ||
+state.character.primary_facet` and offers that Facet's *domain list* as the
+"choices" — a Body-Facet character selecting Weapon Mastery would be shown
+Soul domain names (Storm, Fire, ...) as candidate weapon types. This means
+there is currently **no working choice picker at all** for any of the three
+Techniques this cycle's auto-apply exists to serve, independent of which
+vocabulary `weapon_category` uses.
+
+**Why this was not silently fixed:** reconciling the two taxonomies is a
+content/architecture decision, not a wiring bug — plausible directions
+include (a) migrating Weapon Mastery's `choice_prompt` to IV.1's five
+categories, which breaks the existing II.4a text and the III.3:513 vignette
+and needs re-writing both; (b) keeping Weapon Mastery's own vocabulary and
+adding a second reference table mapping weapon-family choices to the set of
+IV.1 categories they can appear as, so the trigger checks membership rather
+than equality; (c) something else. Any of these is a Planner-level call, and
+TD-7's files list (`websocket.py`, `play.js`, `index.html`,
+`test_websocket.py`) does not include `II.4a`, `builder.js`, or a new
+reference table — inventing a fix here would be scope creep past what TD-7
+asked for and would very likely collide with a decision Planner should make
+deliberately.
+
+**What ships regardless:** the composition mechanism (`combat.py`,
+already-done TD-5) is generic and correct — it was tested with `weapon_category:
+"blades"` directly in `test_combat.py` before this pass, and this pass's
+websocket tests use compatible values (`"light"`/`"light"`) precisely to
+route around this defect rather than depend on it being fixed. TD-7 through
+TD-11 are complete and tested as specified; only Weapon Mastery's *real-play*
+auto-fire rate is affected (3 of its 4 choices), and only once
+`pickTechniqueChoice` is also fixed does a player have any way to make that
+choice through the UI at all today, auto-apply or not.
+
+**The specific question for Planner:** how should Weapon Mastery's
+`choice_prompt` vocabulary (`blades`/`blunt`/`polearms`/`unarmed`) relate to
+`weapon_category`'s vocabulary (`heavy`/`standard`/`light`/`ranged`/`unarmed`)
+so the Technique can auto-fire for all four of its choices, not just
+`unarmed`? And, separately but in the same area: `pickTechniqueChoice` needs
+a non-domain code path for `has_choice` Techniques — should it read the
+choices from `step_trigger` (e.g. a `choices:` list you'd add to the schema),
+or elsewhere?
+
+**Recommend:** *"Switch to Opus to resolve this escalation before continuing
+to TD-12 onward."* This does not block Q3 (TD-12–TD-15), which is unrelated
+machinery, but it should land before anyone treats Weapon Mastery's auto-apply
+as working end-to-end in play.
+
+**Resolved.** Planner ruled in `docs/DESIGN_technique_difficulty.md` §8
+(2026-08-02): the two vocabularies are orthogonal axes and both stay —
+`weapon_category` keeps its TD-7 job, a new `weapon_type` field carries
+Weapon Mastery's own fictional taxonomy, and `TechniqueDef.choices` fixes the
+second, compounding defect (`pickTechniqueChoice`'s missing non-domain code
+path). Implemented as TD-18/TD-19/TD-20 below. Return to Worker to continue
+from `docs/TASKS_technique_difficulty.md` TD-18.
+
+---
+
+## DESIGN §8 amendment — TD-18, TD-19, TD-20
+
+Resolves the escalation above. Full ruling in
+`docs/DESIGN_technique_difficulty.md` §8 — summary: `weapon_category` (IV.1,
+mechanical, sets the Strike attribute) and `weapon_type` (II.4a, fictional,
+what *Weapon Mastery* masters) are orthogonal and both ship on the Strike
+message; a longsword is `standard` category and `blades` type at once, so
+neither list can be collapsed into the other without breaking one job.
+
+### TD-18 — `weapon_type` on the Strike, `weapon_mastery` retargeted
+
+**`app/facets/schema.py`:** `EquipmentDef` gains `weapon_types: list[str]`
+(mirrors `weapon_categories` but is a flat list — there is no attribute to
+default from this vocabulary). `TechniqueDef` gains `choices: list[str] |
+None` (TD-19, but added here since both land in the same class).
+
+**`facets/base/facet.yaml`:** `equipment.weapon_types: [blades, blunt,
+polearms, unarmed]` (no ranged entry — content gap, docs/TODO.md T8, not
+fixed here). `weapon_mastery.step_trigger.match` retargeted from
+`weapon_category` to `weapon_type`; `weapon_mastery`, `acclimated`, and
+`field_of_mastery` each gain a `choices` list matching their
+`choice_prompt` prose word-for-word.
+
+**`app/game/combat.py`:** no logic change — `apply_character_difficulty_step`
+already reads whatever field name `trigger.match` names out of the `context`
+dict generically; only its docstring gained a `weapon_type` mention. This is
+worth stating explicitly since it is the reason the fix is data-only: the
+"generic composition, no hardcoded field names" property the function was
+built with (TD-6) is exactly what let the escalation be closed without
+touching the one file `CLAUDE.md` says may carry this rule.
+
+**`app/api/websocket.py`** (`_handle_strike`): a second optional field,
+`weapon_type`, alongside `weapon_category` — same validation shape (checked
+against `ruleset.equipment.weapon_types`, rejected with an error message if
+present but unrecognised, silently absent if not sent), added to both the
+difficulty-composition context dict and the `strike_result` broadcast.
+`weapon_category` is untouched — same code, same job, still in both places.
+
+**`app/static/index.html` / `play.js`:** a second picker,
+`#strike-weapon-type`, beside the existing category picker. Deliberately no
+`onchange` handler — TD-18's constraint #1 is that `weapon_category` alone
+still defaults the attribute; `weapon_type` sets nothing.
+
+**Tests** (`tests/test_websocket.py`, `TestCombatGameplayLoop`): rewrote the
+two TD-7-era tests that fired Weapon Mastery through `weapon_category` — that
+route only ever worked because both tests used `"light"` as a stand-in value
+for both fields at once, which is exactly the bug the escalation found —
+into the acceptance criteria's five: fires on matching `weapon_type`, doesn't
+fire on mismatched `weapon_type`, doesn't fire when `weapon_type` absent,
+doesn't fire on `weapon_category` alone (proving the axes are separate), and
+the III.3:513 regression (Mordai, Weapon Mastery in blades, Standard →
+Easy, `weapon_category: "standard"` + `weapon_type: "blades"` both present,
+matching how a real Strike would actually be sent). Added round-trip and
+unknown-value error tests for `weapon_type` mirroring the pre-existing
+`weapon_category` coverage. Updated `test_strike_without_weapon_category_
+behaves_as_today` to also assert `weapon_type is None`, and
+`TestCastHandlerUnaffectedByDifficultyStep`'s technique_choices/context values
+from `"light"` to `"blades"`/`weapon_type` so the test still proves what it
+claims to (a Technique that *would* fire on a Strike) now that `"light"`
+alone can no longer make Weapon Mastery fire at all.
+
+**`tests/test_facets_schema.py`:** updated the one integration assertion that
+pinned the old match field (`TestDifficultyStepMetadataInBaseFacet
+.test_auto_triggers_match_declared_fields`); updated the isolated unit test
+`test_auto_trigger_technique_parses` for consistency (it used
+`weapon_category` as a stand-in value, unrelated to real facet.yaml data, but
+leaving it stale next to the real fix would mislead a future reader). Added
+`TestWeaponCategories.test_weapon_types_present_and_orthogonal_to_categories`.
+
+### TD-19 — `choices` as data
+
+**`app/facets/schema.py`:** documented above; `choices` defaults to `None` so
+every pre-existing Technique parses unchanged.
+
+**`facets/base/facet.yaml`:** `weapon_mastery` → `[blades, blunt, polearms,
+unarmed]`; `acclimated` → `[extreme cold, extreme heat, altitude,
+deprivation]`; `field_of_mastery` → `[history, arcane theory, natural
+sciences, theology, law, languages, geography]`, with a comment noting these
+are suggestions, not a closed set (II.4a: "or another domain with MM
+approval") — nothing in the schema or the engine enforces membership
+(INV-8), by design; there is no "closed vs. open" flag anywhere, `builder.js`
+special-cases `field_of_mastery` by id instead (TD-20).
+
+**Tests** (`tests/test_facets_schema.py`): unit tests
+`test_no_choices_parses_unchanged` / `test_technique_with_choices_parses`
+(`TestTechniqueDef` or wherever the existing TD-4 class lives — placed next
+to `test_invalid_difficulty_step_raises`). New integration class
+`TestNonDomainTechniqueChoices` against the real ruleset: all three
+Techniques carry `choices`; an ordinary Technique (`forcing_hand`) still
+parses without it; `choices` values individually appear (case-insensitively)
+in the corresponding `choice_prompt` — the acceptance test TD-19 names as
+the one that matters, since it is what keeps the book and the data from
+silently drifting apart; and one assertion each pinning the three lists by
+exact/partial value.
+
+### TD-20 — the picker's non-domain fallback
+
+**`app/static/js/builder.js`:** `pickTechniqueChoice` now checks `def.choices`
+first — if present and non-empty, delegates to a new `pickFromChoicesList`
+that renders a `selectDialog` straight from the list (`value === label`, no
+transformation), with one addition: for `field_of_mastery` specifically
+(matched by id, since there is no schema-level "open-ended" flag — DESIGN §8
+was explicit that adding one wasn't warranted for a single Technique) an
+`"Other (type your own)..."` option drops into `promptDialog` for free text.
+Weapon Mastery and Acclimated are closed sets and offer only what `choices`
+lists. The pre-existing domain-list branch is unchanged and only runs when
+`def.choices` is absent — which, after TD-19, is true of every
+domain-granting Technique and false of exactly the three this cycle touches.
+
+**Tests** (`tests/e2e/test_ui_flows.py`, new class
+`TestTechniqueChoicePicker`): two tests. `test_weapon_mastery_choice_reaches_
+technique_choices_on_the_character` grants a real Technique pick (two Body
+skill advances via a direct `skill_advance` WS call — the MM's "Advance
+Skill" button in `index.html` never sends its `marks` field at all, a defect
+independent of this cycle and not fixed here since it isn't in scope; calling
+`sendWS` directly is the same class of workaround the file already uses),
+reads the real `weapon_mastery` Technique definition out of the correctly-
+shaped nested `ruleset.techniques.body.branches[].tiers[].techniques[]`, and
+calls `pickTechniqueChoice` on it directly rather than through
+`selectTechnique`/a button click. `test_domain_granting_technique_keeps_the_
+domain_list_behaviour` does the same against `arcane_study` (a real
+domain-granting Technique with no `choices`) and asserts the picker still
+offers domain-shaped options (`"Name (type)"` labels), proving the new branch
+is additive, not a replacement.
+
+**Why not driven through the real "Select" button.** While staging this test,
+found that `builder.js::renderBuilderTechniques`/`selectTechnique` read
+`state.ruleset.character_facets.find(...).techniques` — a field that does not
+exist on the wire (`CharacterFacetDef` is `id`/`name`/`description`/
+`major_attribute` only; the real Technique tree is the separate top-level
+`ruleset.techniques[facet_id]`). The "Available" Technique list in the
+Builder tab is therefore always empty, and the button the acceptance
+criteria describes clicking does not currently render. This is a real,
+independent bug (`docs/TODO.md` T9) — not something TD-18/19/20 touches or
+was asked to fix, and fixing `renderBuilderTechniques`, `selectTechnique`,
+and `app.js::techniqueDisplayName` (same root cause, third call site) is new
+scope across two files outside all three tasks' file lists. The test instead
+calls `pickTechniqueChoice` directly with a correctly-sourced Technique
+definition, which is exactly what TD-20 asked to fix and is sufficient to
+prove it, using the same direct-injection precedent TD-10's Strike-banner
+tests already established in this file for an analogous situation (full
+round trip via another path is separately broken or impractical to stage).
+
+**Two more pre-existing gaps found staging the same test, also out of scope
+and also filed** (`docs/TODO.md` T10, T11): the `skill_advanced` broadcast
+never carries `technique_picks_available` and `app.js` never applies it
+(so a granted pick is invisible client-side until a reload); and
+`onTechniqueSelected` never writes `msg.choice` into
+`state.character.technique_choices` (so a made choice is likewise invisible
+client-side until a reload), and separately sets `magic_technique_active =
+true` unconditionally for every Technique, not just magic-granting ones. Both
+are proven real (not test error) because the *server-side* character state
+is correct in both cases — verified by reloading the page (which re-fetches
+full session state via `onStateReceived`, carrying the true values) rather
+than trusting the incremental broadcast handlers. The test routes around
+both rather than fixing them.
+
+### Test count
+
+Backend (`test_websocket.py`, `TestCombatGameplayLoop`): the 2 TD-7-era
+weapon-mastery tests were replaced by 5 (net +3), plus 2 new round-trip/
+unknown-value `weapon_type` tests (net +2) — net **+5**. The `weapon_type is
+None` addition to the existing backward-compat test and the cast-handler
+value fix are edits in place, not new tests.
+`test_facets_schema.py`: 2 new unit tests + 1 new integration test
+(`TestWeaponCategories`) + 6 new tests (`TestNonDomainTechniqueChoices`) —
+net **+9**. E2e: 2 new tests (`TestTechniqueChoicePicker`) — net **+2**.
+
+`python3 -m pytest -q` from `software/`: **1356 passed**, zero failures, zero
+unexpected skips. Ran in the foreground, full suite including the Playwright
+e2e module, ~4m52s. (1340 baseline + 5 test_websocket.py + 9
+test_facets_schema.py + 2 e2e = 1356.)
+
+### Discovered, filed, not fixed (all out of TD-18/19/20 scope)
+
+- **T9** — `character_facets[].techniques` doesn't exist; the Builder tab's
+  Technique list is always empty.
+- **T10** — `skill_advanced` broadcast omits `technique_picks_available`;
+  `app.js` never applies it.
+- **T11** — `onTechniqueSelected` never writes the choice into
+  `technique_choices`; also sets `magic_technique_active` unconditionally.
+
+None of these were introduced by this cycle — all three predate TD-18/19/20
+and were only surfaced because TD-20's acceptance criteria required actually
+driving the Technique-selection flow, which nothing had exercised
+end-to-end before.
+
+---
+
+## Q3 — the licensed override (TD-12, TD-13, TD-14, TD-15, TD-16)
+
+**Date:** 2026-08-02
+**Scope:** the whole Q3 block plus the shared MM1 calibration sentence (TD-16),
+per assignment. TD-1 … TD-11 and TD-18 … TD-20 were already done (see above);
+TD-17 was already recorded in `docs/TODO.md` T7. This entry closes the cycle.
+
+### TD-12 — schema and data for the override flag
+
+`TechniqueDef` (`software/app/facets/schema.py`) gains
+`removes_target_from_conflict: bool = False`, documented in the class
+docstring in the existing style (same pattern as `difficulty_step`/
+`choices`). `facet.yaml`'s `the_final_blow` entry is the only Technique that
+sets it `true`.
+
+`TestFinalBlowOverrideFlag` (`test_facets_schema.py`) pins the count at
+exactly one and names it, mirroring `TestDifficultyStepMetadataInBaseFacet`'s
+pattern from TD-6: `test_exactly_one_technique_carries_the_flag`,
+`test_the_final_blow_carries_the_flag`,
+`test_an_ordinary_technique_does_not_carry_the_flag`.
+
+### TD-13 — resolve the removal as a defeat event
+
+New `combat.py` function `apply_final_blow_removal(resolve_current,
+phase_thresholds=None) -> FinalBlowResult`. Deliberately a **new dataclass**
+(`FinalBlowResult`), not a reuse of `ResolveDamageResult` — the two must be
+distinguishable at the *type* level, not just by field values, so a future
+sim series or a transcript reader can tell a licensed-override removal apart
+from an ordinary Strike that happened to zero an enemy's Resolve, without
+relying on a caller remembering to check a string. `FinalBlowResult` also
+carries `cause: str = "final_blow"` for callers (the WS broadcast) that want
+a machine-readable label rather than a type check.
+
+The function always sets `resolve_current = 0` and `defeated = True`
+(the removal works on any target, Bosses included, per the BRIEF), and — the
+P11-invariant part — routes the crossing check through the shared
+`phase_crossed` primitive, the same one `apply_resolve_damage` uses, so a
+Boss phase sitting between the target's prior Resolve and 0 still fires
+exactly as it would from an ordinary Strike. It never does `resolve_current
+= 0` as a bare assignment outside of building the result.
+
+`TestApplyFinalBlowRemoval` (`test_combat.py`): 4 tests —
+`test_removal_produces_a_defeat_event`,
+`test_removal_routes_through_phase_crossed` (including the "already at/under
+threshold: no re-fire" case, mirroring `TestApplyResolveDamage`'s existing
+phase tests), `test_transcript_entry_is_distinguishable_from_a_resolve_zero_defeat`
+(asserts both `isinstance`/type difference and the `cause` field),
+`test_no_raw_resolve_current_zero_write_in_source` (inspects the function's
+source text for `phase_crossed(` and the absence of a bare
+`resolve_current = 0` assignment — a structural guard against a future edit
+reintroducing the bypass).
+
+The once-per-session gate, the Spark spend, the "succeed" (7+) check, and
+whether the removal *commits* are all left to the caller (websocket.py) —
+`apply_final_blow_removal` only resolves the mechanical consequence once a
+caller has already decided the Technique fires. No escalation was needed:
+routing through the canonical path did not require changing
+`apply_resolve_damage`'s or `phase_crossed`'s signature — a sibling function
+with the same shape was sufficient.
+
+### TD-14 — wire Final Blow through the strike handler
+
+Two-phase flow, matching DESIGN §4's "auto-apply governs difficulty steps,
+not actor removal":
+
+1. **Offer** — the player declares Final Blow with their Strike (`final_blow:
+   true` on the `strike` message). `_handle_strike` (`websocket.py`) checks
+   preconditions *before* the roll resolves and *before* `_spend_sparks` is
+   called, so a rejected declaration costs the player nothing: the Technique
+   must be unlocked (`"the_final_blow" in character.techniques`), unused this
+   session (`character.techniques_used_this_session` — the existing field,
+   no new one added, per the assignment's constraint), the roll must be a
+   Combat roll (`skill_id == "combat"`, the Strike handler's own default), and
+   a Spark must be requested on this roll (`sparks_spent >= 1`). Once the
+   roll resolves, `final_blow_available` on the `strike_result` broadcast is
+   `true` only if `final_blow_requested` and the outcome is `full_success` or
+   `partial_success` (7+, both success tiers, per the BRIEF) — never on
+   `failure`. Firing only offers the removal; nothing about any enemy changes
+   and the Technique is not yet marked used.
+2. **Commit** — a new MM-gated WS event, `final_blow_confirm` (`player`,
+   `tracker_key`), dispatched to a new handler `_handle_final_blow_confirm`.
+   It re-validates (technique unlocked, not already used — defense in depth
+   against a stale or replayed confirm), looks up the tracked enemy, calls
+   `combat.apply_final_blow_removal` through the same `before`-Resolve
+   pattern `_handle_enemy_strike` already uses, sets
+   `enemy.resolve_current = result.resolve_current`, and **only here**
+   appends `"the_final_blow"` to `character.techniques_used_this_session` and
+   persists it (`session.save_character_to_disk`). The broadcast is
+   `enemy_updated` extended with `cause: "final_blow"`, `player`, and
+   `technique_id` — reusing the existing message type (so the client's
+   existing `onEnemyUpdated` handling of `defeated` keeps working
+   unmodified) while staying distinguishable via the extra fields, matching
+   TD-13's transcript-distinguishability requirement one layer up.
+
+Client (`play.js`, `index.html`): a "The Final Blow" checkbox on the Strike
+sub-form (cleared after each Strike, matching the once-per-session gate
+being enforced server-side); an MM-only `notify(...)` prompt on
+`strike_result` when `final_blow_available` is true, mirroring the existing
+"Apply" prompt for ordinary Strike outcomes, with a "Confirm Final Blow"
+action that sends `final_blow_confirm`; and a distinguishing chat line in
+`onEnemyUpdated` when `msg.cause === 'final_blow'` ("removed from the
+conflict — The Final Blow" rather than "is defeated"). No e2e test was
+added for this — TD-14's acceptance criteria list only WS-level tests, and
+the wiring is exercised end-to-end by the WS test suite; the client changes
+are the minimum needed for the feature to be usable at a table.
+
+`TestFinalBlowLicensedOverride` (`test_websocket.py`): 8 tests —
+`test_fires_on_full_success`, `test_fires_on_partial_success`,
+`test_does_not_fire_on_failure` (dice pinned via
+`patch("random.randint", ...)`, values chosen against Zahna's known +1
+Strength modifier and Standard difficulty to land deterministically in each
+outcome band — see the class docstring for the arithmetic),
+`test_second_use_in_same_session_is_refused`,
+`test_removal_does_not_commit_without_mm_confirmation` (asserts the enemy's
+`resolve_current` is untouched and the Technique is not marked used after a
+firing Strike with no confirm),
+`test_mm_confirm_commits_the_removal`, `test_second_mm_confirm_is_refused`,
+`test_non_mm_cannot_confirm_final_blow` (a player token gets "Unknown event
+type" — `final_blow_confirm` is dispatch-gated `and is_mm`, same pattern as
+`enemy_strike`).
+
+### TD-15 — Q3 prose
+
+II.4a's *The Final Blow* entry gains one sentence between the description
+and `Normal:`: "'Succeed' means a **10+ or a 7–9** — both success tiers
+count. On a 7–9, the partial's usual cost still applies and shapes how the
+removal happens in the fiction, but never whether it happens: the target is
+gone either way." The `Normal:` field ("A Spark adds a d6 and drops the
+lowest. A Strike depletes Resolve, and riders never defeat an enemy on their
+own") still reads true afterward — it describes the baseline the Technique
+departs from, which the new sentence doesn't touch.
+
+MM1 gains an **MM Note** box in the *Bosses* section ("build for the early
+exit, not against it"): a capstone landing early doesn't just skip a phase,
+it skips the encounter, so front-load anything a phase change was protecting
+rather than gating it behind Resolve grinding.
+
+**III.3 verified byte-identical.** `md5sum player_handbook/III.3_Combat.md`
+before and after this pass: `45556c573be382c27af8ae6523674d61` both times.
+`grep`-confirmed the rider sentence is untouched: "Riders never defeat an
+enemy on their own — **Resolve does that; a rider only shapes the blows that
+follow.**" (III.3:140).
+
+### TD-16 — the MM1 calibration sentence
+
+One bullet added to *Scaling Notes* (end of the Encounter Recipe Table
+section): "The recipes above are calibrated for a baseline party —
+`standard_party()` in the simulation corpus carries no Techniques. A party
+fielding step-easier Strike Techniques ... or a Tier 3 capstone like *The
+Final Blow* runs a Recipe Table encounter about a band hot — treat the
+difficulty row you picked as one notch easier than printed." Advisory prose
+only — the Recipe Table's numbers (Tables MM1–7 and MM1–8) are byte-for-byte
+unchanged; no simulation was re-run.
+
+### Generated finding aids
+
+Regenerating `List_of_Boxes.md`/`List_of_Tables.md` (`tools.build_table_register`)
+and `player_handbook/Index.md` (`tools.build_index`) was required to pick up
+the new MM Note box and keep INV-9/INV-10 green — `test_table_register_is_up_to_date`
+failed until the register was regenerated. The Index diff (176 insertions)
+is larger than this pass's own edits account for; it was already stale
+before this session started (from TD-18…TD-20's prose changes, which
+predate this Worker's involvement) and the regeneration caught that
+staleness too, which is expected and correct — `Index.md`/`List_of_*.md`
+are never hand-edited (`CLAUDE.md`). `tools.build_bestiary` was also run for
+completeness; it reported 0 files changed.
+
+### Test count
+
+`test_facets_schema.py`: +3 (`TestFinalBlowOverrideFlag`).
+`test_combat.py`: +4 (`TestApplyFinalBlowRemoval`).
+`test_websocket.py`: +8 (`TestFinalBlowLicensedOverride`).
+Net **+15** over the TD-18…TD-20 baseline of 1356.
+
+`python3 -m pytest -q` from `software/`: **1371 passed**, zero failures, zero
+unexpected skips, run in the foreground to completion (full suite including
+the Playwright e2e module). `test_docs_consistency.py` (31 tests, including
+INV-6, INV-9, INV-11, INV-12, INV-13, INV-14) green after the finding-aid
+regeneration.
+
+---
+
+## Cycle closed
+
+TD-1 through TD-20 are all done. Q1 (composition), Q2 (pricing/wording
+defect), and Q3 (licensed override) — all three rulings in `DECISIONS.md`
+B4 — are implemented, tested, and documented, including the DESIGN §8
+amendment (the two weapon vocabularies) raised and resolved mid-cycle.
+`docs/TASKS_technique_difficulty.md`'s progress table is updated to reflect
+the whole cycle complete. No outstanding escalations. Two follow-ups remain
+recorded in `docs/TODO.md` for future work, neither blocking this cycle:
+T7 (*Pressure Point*'s scene-effect store, deliberately deferred per DESIGN
+§2.5) and T9/T10/T11 (pre-existing Builder-tab Technique-selection gaps,
+found but out of scope while staging TD-20's e2e test).

--- a/docs/TASKS_technique_difficulty.md
+++ b/docs/TASKS_technique_difficulty.md
@@ -1,0 +1,397 @@
+# TASKS — Technique difficulty, domain pricing, and licensed overrides
+
+**Design:** `docs/DESIGN_technique_difficulty.md`. **Ruling:** `docs/DECISIONS.md` B4.
+**Brief:** `docs/BRIEF_technique_difficulty.md`.
+
+Worker protocol: pick **one** task, open only the files it names, write the test
+first, run it red, implement, run it green, run the full suite, update this file
+and append to `docs/LOG_technique_difficulty.md`, then **stop and report**.
+
+Every task below is self-contained. Do not rely on chat history.
+
+---
+
+## Q2 — pricing and the wording defect *(do first: independent, closes a live defect)*
+
+### TD-1 — Pin the two domain grant routes
+
+**Files:** `software/tests/test_ascendant_domain.py` (add), read-only:
+`software/app/game/character.py:406–410`, `software/app/game/engine.py:330–338`.
+
+**Do:** add three tests pinning B4 Q2 as canon.
+
+1. Ascendant Domain's prismatic territory resolves on the **Broad** table with **no**
+   additional step, at all three scopes.
+2. A Second Domain grant resolves on **its own domain type's** table, one step harder.
+3. **The Focused-primary case**: a character whose primary domain is Focused and whose
+   Second Domain grant is Standard prices at *Standard-plus-one-step*, not at
+   *Focused-plus-one-step*. This is the case the old wording broke.
+
+**Acceptance:** all three pass against the **current** engine without engine changes.
+If any fails, the engine does not implement B4 Q2 — stop and escalate to Planner;
+do not "fix" the engine to match the test.
+
+---
+
+### TD-2 — Re-anchor the Second Domain wording on five surfaces
+
+**Files:** `player_handbook/II.4b_Character_Creation_Facet_Mind.md`,
+`player_handbook/II.4c_Character_Creation_Facet_Soul.md`,
+`software/facets/base/facet.yaml` (`second_domain_mind.roll`, `second_domain.roll`),
+`mm_manual/MM5_Quick_Reference.md`.
+
+**Do:** replace "one difficulty step harder **than your primary domain**" with
+"one difficulty step harder **than normal for that domain**" everywhere it appears —
+body prose, both `roll:` strings, and the MM5 compression. **One commit, all five.**
+
+Do not touch the `Normal:` fields; they already read correctly.
+
+**Acceptance:** TD-1 still green. `grep -rn "harder than your primary domain"`
+returns nothing across `player_handbook/`, `mm_manual/`, and `facet.yaml`. INV-6
+(MM5 typographic dashes) and INV-14 (Technique headers vs facet.yaml) still pass.
+
+**Test:** add to `software/tests/test_docs_consistency.py` — no book or `facet.yaml`
+surface contains the old anchoring. This is the regression guard; the string is
+short and will otherwise creep back in a copy-paste.
+
+---
+
+### TD-3 — Record the Q2 defect as closed
+
+**Files:** `docs/LOG_technique_difficulty.md` (create).
+
+**Do:** open the log with the Q2 entry — what the defect was, why it was invisible
+(it only bites Focused-primary casters), the five surfaces, and the tests that now
+pin it.
+
+**Acceptance:** log exists and names TD-1's three tests by function name.
+
+---
+
+## Q1 — the composition mechanism
+
+### TD-4 — Schema: `difficulty_step` and `step_trigger`
+
+**Files:** `software/app/facets/schema.py` (`TechniqueDef`, line ~86),
+`software/tests/test_facet_schema.py`.
+
+**Do:** add two optional fields, documented in the class docstring in the existing
+style:
+
+- `difficulty_step: Literal["easier", "harder"] | None = None`
+- `step_trigger: StepTriggerDef | None = None`, where `StepTriggerDef` is a new
+  model: `kind: Literal["auto", "declared"]`, `match: str | None`,
+  `against: str | None` (`"choice"` or a literal value).
+
+Both optional, so every existing Technique parses unchanged.
+
+**Acceptance:** `facet.yaml` loads with no change to it. Three tests: a Technique
+with no step parses; one with an auto trigger parses; an invalid `kind` raises.
+
+---
+
+### TD-5 — The composition rule in `combat.py`
+
+**Files:** `software/app/game/combat.py`, `software/tests/test_combat.py`.
+
+**Do:** add `apply_character_difficulty_step(declared_label, character, context,
+ruleset) -> tuple[str, str | None]` per DESIGN §2.2.
+
+- Declared label first, character step second, ladder clamps via the existing
+  `_engine._step_difficulty_easier` / `_harder`.
+- **At most one** character-side step per roll.
+- Precedence when several qualify: player-declared beats auto, then lowest
+  technique id.
+- Only Techniques the character has actually unlocked are eligible.
+- Returns the final label and the technique id that moved it (or `None`).
+
+**This is the rule's only home.** It must not be duplicated in `websocket.py` or in
+the simulator (`CLAUDE.md` iron law).
+
+**Acceptance — write these tests first**, they are DESIGN §5's list:
+clamping from Easy; two qualifying Techniques yield one step and a deterministic id;
+unlocked-only; absent context field does not fire; mismatched choice does not fire;
+Hard + step → Standard; declared beats auto.
+
+---
+
+### TD-6 — Populate the step metadata in `facet.yaml`
+
+**Files:** `software/facets/base/facet.yaml`, `software/tests/test_facet_schema.py`.
+
+**Do:** add `difficulty_step` and `step_trigger` to exactly five Techniques, per
+DESIGN §2.3: `weapon_mastery`, `acclimated`, `field_of_mastery` (auto, match against
+`choice`), `steady_hand` (auto, `skill_id` against literal `finesse`),
+`the_uncanny_angle` (declared).
+
+**Do not** add them to `pressure_point` — it is deferred (DESIGN §2.5).
+
+**Acceptance:** exactly five Techniques carry `difficulty_step`. INV-14 passes. A
+test asserts the count is five and names them, so a sixth cannot be added without
+a deliberate test change.
+
+---
+
+### TD-7 — Carry `weapon_category` on the Strike
+
+**Files:** `software/app/api/websocket.py` (strike handler, ~585),
+`software/app/static/js/play.js` (~1072), `software/app/static/index.html`,
+`software/tests/test_websocket.py`.
+
+**Do:** add an optional `weapon_category` to the strike message, one of the five
+IV.1 categories (`heavy`, `standard`, `light`, `ranged`, `unarmed`). Add a picker in
+the strike UI.
+
+**Take the side benefit** (DESIGN §2.4): IV.1 says category sets the Strike
+attribute, so the picker should drive the attribute selection — heavy → Strength,
+light/ranged → Dexterity, standard/unarmed → player's choice of Strength or
+Dexterity. Do **not** restrict what the client may send: INV-8 says the books may
+not restrict a Strike pairing the engine permits, and the same applies here. The
+picker is a default, not a gate.
+
+**Acceptance:** a strike with no `weapon_category` behaves exactly as today.
+Three tests: absent field is accepted; a valid category round-trips; an unknown
+category is rejected with an error message rather than silently ignored.
+
+---
+
+### TD-8 — Carry `hazard_type` and `knowledge_field` on generic rolls
+
+**Files:** `software/app/api/websocket.py` (generic roll handler, ~275/310),
+`software/app/static/js/play.js`, `software/tests/test_websocket.py`.
+
+**Do:** add two optional strings to the roll message. Both absent by default; an
+absent field means the corresponding auto trigger does not fire.
+
+**Acceptance:** existing roll messages are unaffected. Two tests: absent fields
+accepted; values round-trip into the roll context.
+
+---
+
+### TD-9 — Wire the three handlers
+
+**Files:** `software/app/api/websocket.py` (strike ~585, generic roll ~275/310,
+reaction ~1111), `software/tests/test_websocket.py`.
+
+**Do:** in each of the three handlers, after the difficulty label is known and
+**before** `RollRequest` is built, call `apply_character_difficulty_step` and use the
+returned label. Carry the returned technique id through to the broadcast payload.
+
+Do **not** wire the magic handler (~950) — DESIGN §2.6.
+
+**Acceptance:** three tests, one per handler: a qualifying Technique steps the label;
+a non-qualifying one does not; the applied technique id appears in the payload.
+A fourth test asserts the magic handler is unaffected.
+
+---
+
+### TD-10 — Show both moves in the roll banner
+
+**Files:** `software/app/static/js/play.js`, `software/app/static/js/components.js`,
+`software/tests/e2e/test_ui_flows.py`.
+
+**Do:** when a payload carries an applied technique id, the banner reads
+`Hard (MM) → Standard (Weapon Mastery)`. When it does not, the banner is unchanged.
+
+This is required, not polish (DESIGN §2.7): auto-apply is only acceptable because
+the step is visible.
+
+**Acceptance:** an e2e test asserting both moves render when a Technique applies,
+and that an ordinary roll's banner is unchanged.
+
+---
+
+### TD-11 — Legislate Q1 in III.1, compress everywhere else
+
+**Files:** `player_handbook/III.1_Core_Resolution.md` (*Difficulty*),
+`player_handbook/III.3_Combat.md` (Strike difficulty note),
+`mm_manual/MM5_Quick_Reference.md`, `mm_manual/MM2_Session_Design.md`.
+
+**Do:** one legislative paragraph in III.1 *Difficulty* — the MM's call first, the
+character's step second, ladder clamps, at most one character-side step per roll.
+Every other surface **compresses** it; none restates it (quick-refs iron law).
+
+MM2 gets the guardrail note from DESIGN §2.5: an MM applying *Pressure Point* by
+hand must not also let a Technique step the same roll.
+
+**Acceptance:** INV-9 through INV-14 pass. `docs`-consistency stays green. No surface
+other than III.1 states the rule in full.
+
+---
+
+## Q3 — the licensed override
+
+### TD-12 — Schema and data for the override flag
+
+**Files:** `software/app/facets/schema.py`, `software/facets/base/facet.yaml`,
+`software/tests/test_facet_schema.py`.
+
+**Do:** add `removes_target_from_conflict: bool = False` to `TechniqueDef`; set it
+true for `the_final_blow` and nothing else.
+
+**Acceptance:** a test asserts exactly one Technique in `facet.yaml` carries the
+flag, and names it. Overrides must stay greppable and countable.
+
+---
+
+### TD-13 — Resolve the removal as a defeat event
+
+**Files:** `software/app/game/combat.py`, `software/tests/test_combat.py`.
+
+**Do:** a function that resolves a Final Blow removal through the **canonical defeat
+path**, never a raw `resolve_current` write.
+
+**P11 invariant:** every `resolve_current` mutation routes through `phase_crossed`.
+The removal must be distinguishable in the transcript from an ordinary defeat so a
+future sim series can count capstone removals.
+
+**Escalate rather than decide** if this requires changing the defeat path's
+signature (DESIGN §7.2).
+
+**Acceptance:** three tests — removal produces a defeat event; it routes through
+`phase_crossed`; the transcript entry is distinguishable from a Resolve-0 defeat.
+A fourth asserts no code path writes `resolve_current = 0` directly for this case.
+
+---
+
+### TD-14 — Wire Final Blow through the strike handler
+
+**Files:** `software/app/api/websocket.py`, `software/app/static/js/play.js`,
+`software/tests/test_websocket.py`.
+
+**Do:** the player declares Final Blow with their Strike. Spark spent, Combat roll
+resolved; **on 7+** the removal is offered. **MM confirmation is required** before it
+commits — auto-apply governs difficulty steps, not actor removal.
+
+Frequency uses the existing `Character.techniques_used_this_session`. No new field.
+
+**Acceptance:** four tests — fires on 10+; fires on 7–9; does not fire on 6−;
+a second use in the same session is refused. One more: the removal does not commit
+without MM confirmation.
+
+---
+
+### TD-15 — Q3 prose
+
+**Files:** `player_handbook/II.4a_Character_Creation_Facet_Body.md`,
+`mm_manual/MM1_Encounters_and_Enemies.md`.
+
+**Do:** one precision sentence in the *Final Blow* entry — "succeed" means 7+, and
+on a 7–9 the partial's cost shapes the aftermath, never the removal itself. Then
+check the entry's `Normal:` field still reads true.
+
+MM1 gains the encounter-design note: build Bosses so an early exit is a win, not a
+broken script — phase material is forfeit the moment a capstone lands.
+
+**III.3 changes not at all.** That is the ruling.
+
+**Acceptance:** INV-14 passes. `grep` confirms III.3's "riders never defeat"
+sentence is byte-identical to before this cycle.
+
+---
+
+## Shared
+
+### TD-16 — The MM1 calibration sentence
+
+**Files:** `mm_manual/MM1_Encounters_and_Enemies.md`.
+
+**Do:** one advisory sentence near the Recipe Table: the recipes are calibrated for
+baseline parties, and a party fielding step-easier Strike Techniques or a Tier 3
+capstone runs about a band hot.
+
+**Advisory prose only.** Do **not** change the Recipe Table, and do **not** re-run
+Series 7 or 9 — B4 established the corpus is intact. An optional Series 10 to
+quantify "a band hot" is sanctioned but nothing gates on it.
+
+**Acceptance:** the table's numbers are unchanged; INV-9 passes.
+
+---
+
+### TD-17 — Record the *Pressure Point* deferral
+
+**Files:** `docs/TODO.md`.
+
+**Do:** add an item in the file's existing format — what is deferred, why (it is
+party-wide scene state, not roll-time metadata), what happens meanwhile (the MM
+applies it by lowering the label), and what "done" looks like (a scene-effect store
+plus the guardrail counting it as the one character-side step).
+
+**Acceptance:** entry follows the file's what's-wrong / why-deferred / done-when shape.
+
+---
+
+## Amendment — the two weapon vocabularies *(added 2026-08-02, DESIGN §8)*
+
+### TD-18 — Add `weapon_type` and retarget *Weapon Mastery*
+
+**Files:** `software/app/api/websocket.py` (strike handler),
+`software/facets/base/facet.yaml` (`weapon_mastery.step_trigger`, and a
+`equipment.weapon_types` list), `software/app/static/js/play.js`,
+`software/app/static/index.html`, `software/tests/test_websocket.py`.
+
+**Do:** add an optional `weapon_type` (`blades`, `blunt`, `polearms`, `unarmed`) to
+the strike message and a picker beside the existing category picker. Retarget
+`weapon_mastery.step_trigger.match` from `weapon_category` to `weapon_type`.
+
+`weapon_category` keeps its TD-7 job — defaulting the attribute — and is **not**
+removed. The two axes are orthogonal (DESIGN §8).
+
+**Acceptance:** a strike with neither field behaves exactly as today. Four tests:
+Weapon Mastery (blades) + `weapon_type: "blades"` fires; + `weapon_type: "blunt"`
+does not; absent `weapon_type` does not; `weapon_category` alone does **not** fire
+Weapon Mastery, proving the axes are separate. Plus one regression test asserting
+the III.3:513 case — Mordai, Weapon Mastery (blades), Standard → Easy — now works
+end to end, since that is the case B4 cites and the escalation found broken.
+
+---
+
+### TD-19 — Enumerate non-domain Technique choices as data
+
+**Files:** `software/app/facets/schema.py` (`TechniqueDef`),
+`software/facets/base/facet.yaml`, `software/tests/test_facets_schema.py`.
+
+**Do:** add `choices: list[str] | None = None` to `TechniqueDef`. Populate it for
+`weapon_mastery` (blades/blunt/polearms/unarmed), `acclimated` (extreme cold/extreme
+heat/altitude/deprivation), and `field_of_mastery` (the II.4a list, which is
+open-ended — mark it as suggestions, not a closed set).
+
+`choice_prompt` stays as the human-readable label; `choices` is the machine-readable
+option list. Optional, so every other Technique parses unchanged.
+
+**Acceptance:** three tests — the three Techniques carry `choices`; a Technique
+without `choices` parses; the values match the printed `choice_prompt` text so book
+and data cannot drift. INV-14 passes.
+
+---
+
+### TD-20 — Render a picker for non-domain choices
+
+**Files:** `software/app/static/js/builder.js` (`pickTechniqueChoice`),
+`software/tests/e2e/test_ui_flows.py`.
+
+**Do:** `pickTechniqueChoice` currently builds **only** domain lists, so
+`weapon_mastery`, `acclimated`, and `field_of_mastery` offer an empty option set and
+their choices cannot be made at all. Fall back to `def.choices` when the Technique
+is not domain-granting. For `field_of_mastery`, whose list is open-ended, allow a
+free-text entry alongside the suggestions.
+
+**Acceptance:** an e2e test selecting Weapon Mastery and choosing "blades", then
+asserting `technique_choices["weapon_mastery"] == "blades"` on the character. Domain
+Techniques keep their existing behaviour — one test proving that.
+
+---
+
+## Progress
+
+| Task | Status |
+|---|---|
+| TD-1 … TD-3 (Q2) | done — see `docs/LOG_technique_difficulty.md` |
+| TD-4 … TD-6 (Q1 core) | done — see `docs/LOG_technique_difficulty.md` |
+| TD-7 … TD-11 (Q1 wiring/prose) | done — see `docs/LOG_technique_difficulty.md`; escalation resolved by DESIGN §8, see TD-18…TD-20 |
+| TD-12 … TD-15 (Q3) | done — see `docs/LOG_technique_difficulty.md` |
+| TD-16, TD-17 (shared) | done — see `docs/LOG_technique_difficulty.md` |
+| TD-18 … TD-20 (DESIGN §8 amendment) | done — see `docs/LOG_technique_difficulty.md` |
+
+**Cycle complete.** All of TD-1 through TD-20 are done. Q1, Q2, and Q3 (B4) are
+fully implemented, tested, and documented.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -339,3 +339,51 @@ full-reload approach as T10.
 is present, and only sets `magic_technique_active = true` when the selected
 Technique's definition says `magic_granting` (or one of the two domain-grant
 variants) is true — not for every Technique.
+
+---
+
+## T12 — `final_blow_confirm` is not bound to the Strike that offered it
+
+**Source:** review of PR #21, 2026-08-03.
+
+**What's wrong.** The commit handler re-checks only *unlocked* and *not used this
+session*. The 7+ requirement and the Spark cost live in `_handle_strike`'s
+advisory `final_blow_available` flag; the confirm handler holds no reference to a
+roll, an outcome, or a pending offer. `final_blow_available: false` is a client
+hint, not a server gate — so a stale toast, a replayed message, or a hand-crafted
+one could commit a removal after a 6−.
+
+**Why deferred.** The handler is MM-gated and the MM is the game's authority, so
+this is a state-machine gap rather than a privilege escalation. Closing it means
+holding pending-offer state per session, which is a small feature rather than a
+patch.
+
+**Done when:** a Strike that offers Final Blow records a pending offer (attacker,
+target, roll id, expiry), and `final_blow_confirm` refuses anything that does not
+match a live one.
+
+---
+
+## T13 — The Technique step composes on three of six roll paths
+
+**Source:** review of PR #21, 2026-08-03.
+
+**What's wrong.** `apply_character_difficulty_step` is called from the strike,
+generic-roll, and reaction handlers (DESIGN §2.6 named exactly those three).
+Support, Maneuver, and contested rolls never call it. But the book prints
+*Weapon Mastery* as "**Rolls** using your chosen weapon type", not "Strikes".
+
+So Mordai Strikes with his sword at Standard and gets Easy; he Maneuvers with the
+same sword in the same exchange and stays Standard. Same Technique, same weapon,
+two labels, and nothing on screen explains the difference. *Steady Hand* has the
+same shape: a Finesse lockpick sent as a `roll` steps, the same attempt sent as a
+`contested_roll` does not. `weapon_type` is also only read by the strike handler,
+so a generic roll with a blade can never fire *Weapon Mastery* at all.
+
+**Why deferred.** It is a scope question, not a bug in what shipped: the design
+deliberately named three call sites, and widening it touches three more handlers
+plus the client fields that feed them.
+
+**Done when:** either every roll path that can carry a Technique's trigger calls
+the shared function, or the printed Technique text is narrowed to match the paths
+that do — decided deliberately, not by default.

--- a/software/app/api/websocket.py
+++ b/software/app/api/websocket.py
@@ -5,7 +5,7 @@ import asyncio
 import json
 import logging
 import uuid
-from typing import Any
+from typing import Any, Optional
 
 from fastapi import WebSocket, WebSocketDisconnect
 from jose import JWTError
@@ -235,6 +235,8 @@ async def _dispatch(
         await _handle_enemy_update(msg, session, session_id)
     elif event_type == "enemy_strike" and is_mm:
         await _handle_enemy_strike(websocket, msg, session, session_id)
+    elif event_type == "final_blow_confirm" and is_mm:
+        await _handle_final_blow_confirm(msg, session, session_id)
     elif event_type == "remove_enemy" and is_mm:
         await _handle_remove_enemy(msg, session, session_id)
     # --- Threat Clock events (D4, PHB III.2) ---
@@ -261,6 +263,40 @@ def _spend_sparks(character, count: int) -> int:
     for _ in range(actual):
         character.spend_spark()
     return actual
+
+
+def _apply_difficulty_step(
+    character, declared_difficulty: str, context: dict, ruleset,
+) -> tuple[str, Optional[dict]]:
+    """Compose the MM's declared difficulty with any qualifying character-side
+    Technique step (B4 Q1). All the *rule* lives in
+    `combat.apply_character_difficulty_step` — this wrapper only looks up the
+    applied Technique's display name so the caller can put both moves on the
+    broadcast payload for the roll banner (DESIGN_technique_difficulty.md §2.7:
+    "Hard (MM) -> Standard (Weapon Mastery)").
+
+    Every WS handler that resolves a difficulty label (strike, generic roll,
+    reaction) calls this — never `combat_module.apply_character_difficulty_step`
+    directly and never a re-derived step — per TD-9.
+
+    Returns `(final_label, step_info)`. `step_info` is `None` when no
+    Technique fired, which is exactly the "unaffected" case the backward
+    compatibility requirement (TD-7/8/9) hinges on: a caller that ignores a
+    `None` gets today's behaviour byte-for-byte.
+    """
+    final_label, applied_id = combat_module.apply_character_difficulty_step(
+        declared_difficulty, character, context, ruleset,
+    )
+    if applied_id is None:
+        return final_label, None
+    tech_def = ruleset.get_technique(applied_id)
+    step_info = {
+        "technique_id": applied_id,
+        "technique_name": tech_def.name if tech_def else applied_id,
+        "from": declared_difficulty,
+        "to": final_label,
+    }
+    return final_label, step_info
 
 
 def _build_roll_request(character, msg: dict, ruleset, *, press: bool = False) -> RollRequest:
@@ -302,12 +338,32 @@ async def _handle_roll(
         return
 
     sparks_to_spend = _spend_sparks(character, sparks_requested)
+    skill_id = msg.get("skill_id")
+
+    # B4 Q1 (TD-8/TD-9): hazard_type and knowledge_field are optional strings
+    # a generic roll may carry so Acclimated/Field of Mastery can auto-fire.
+    # Absent (None) means the corresponding auto trigger simply does not fire
+    # — existing roll messages that never sent these fields are unaffected.
+    hazard_type = msg.get("hazard_type")
+    knowledge_field = msg.get("knowledge_field")
+    difficulty_declared = str(msg.get("difficulty", "Standard"))
+    difficulty, technique_step = _apply_difficulty_step(
+        character, difficulty_declared,
+        {
+            "skill_id": skill_id,
+            "hazard_type": str(hazard_type) if hazard_type is not None else None,
+            "knowledge_field": str(knowledge_field) if knowledge_field is not None else None,
+            "declared_technique_ids": msg.get("declared_technique_ids"),
+        },
+        session.ruleset,
+    )
+
     request = RollRequest(
         attribute_id=attribute_id,
         attribute_rating=character.attributes[attribute_id],
-        skill_id=msg.get("skill_id"),
-        skill_rank_id=character.skills[msg["skill_id"]].rank if msg.get("skill_id") and msg["skill_id"] in character.skills else None,
-        difficulty_label=msg.get("difficulty", "Standard"),
+        skill_id=skill_id,
+        skill_rank_id=character.skills[skill_id].rank if skill_id and skill_id in character.skills else None,
+        difficulty_label=difficulty,
         sparks_spent=sparks_to_spend,
         description=str(msg.get("description", ""))[:200],
     )
@@ -328,6 +384,7 @@ async def _handle_roll(
         "character_name": character.name,
         "roll": result_dict,
         "character_sparks_remaining": character.sparks,
+        "technique_step": technique_step,
     })
 
 
@@ -582,8 +639,78 @@ async def _handle_strike(
 
     press = bool(msg.get("press", False))
     sparks_requested = int(msg.get("sparks_spent", 0))
-    difficulty = str(msg.get("difficulty", "Standard"))
+    difficulty_declared = str(msg.get("difficulty", "Standard"))
     target_name = str(msg.get("target", ""))
+
+    # TD-7 (B4 Q1 side benefit, IV.1:13-19): an optional weapon category on
+    # the Strike. Reference data only — like `ruleset.equipment.weapon_categories`
+    # itself, this never gates which attribute/skill pairing the client sends
+    # (INV-8: the books may not restrict a Strike pairing the engine permits).
+    # It only (a) feeds Weapon Mastery's auto-trigger and (b) lets the client
+    # default the attribute picker, which is a client-side UX choice, not
+    # something this handler enforces.
+    weapon_category = msg.get("weapon_category")
+    if weapon_category is not None:
+        weapon_category = str(weapon_category)
+        valid_categories = set(session.ruleset.equipment.weapon_categories)
+        if weapon_category not in valid_categories:
+            await manager.send_to(websocket, {
+                "type": "error",
+                "message": f"Unknown weapon category '{weapon_category}'.",
+            })
+            return
+
+    # TD-18 (DESIGN §8): a second, orthogonal, optional field — `weapon_type`
+    # (blades/blunt/polearms/unarmed) is the *fictional* vocabulary Weapon
+    # Mastery masters, not the mechanical one `weapon_category` carries.
+    # Reference data only, same INV-8 reasoning as above; it feeds only
+    # Weapon Mastery's auto-trigger and sets no attribute default.
+    weapon_type = msg.get("weapon_type")
+    if weapon_type is not None:
+        weapon_type = str(weapon_type)
+        valid_types = set(session.ruleset.equipment.weapon_types)
+        if weapon_type not in valid_types:
+            await manager.send_to(websocket, {
+                "type": "error",
+                "message": f"Unknown weapon type '{weapon_type}'.",
+            })
+            return
+
+    # TD-14 (B4 Q3): *The Final Blow* is a licensed override, declared with
+    # the Strike. Preconditions are checked here, before the roll resolves
+    # and before any Spark is actually spent (`_spend_sparks` below), so a
+    # rejected declaration costs the player nothing: not unlocked, already
+    # used this session, not a Combat roll, or no Spark requested on this
+    # roll all refuse outright. Whether it *fires* is decided after the
+    # roll, from the outcome (7+ per the BRIEF). Whether it *commits* is a
+    # separate, later step — MM confirmation via `final_blow_confirm` — per
+    # DESIGN §4: auto-apply governs difficulty steps, not actor removal.
+    final_blow_requested = bool(msg.get("final_blow", False))
+    if final_blow_requested:
+        if "the_final_blow" not in character.techniques:
+            await manager.send_to(websocket, {
+                "type": "error", "message": "The Final Blow is not unlocked.",
+            })
+            return
+        if "the_final_blow" in character.techniques_used_this_session:
+            await manager.send_to(websocket, {
+                "type": "error", "message": "The Final Blow has already been used this session.",
+            })
+            return
+        if str(msg.get("skill_id", "combat")) != "combat":
+            await manager.send_to(websocket, {
+                "type": "error", "message": "The Final Blow requires a Combat roll.",
+            })
+            return
+        # Check the Spark the character *has*, not the one the client asked to
+        # spend: `_spend_sparks` clamps to `character.sparks` and silently
+        # spends 0, so testing the request alone hands the capstone out free to
+        # anyone at 0 Sparks.
+        if sparks_requested < 1 or character.sparks < 1:
+            await manager.send_to(websocket, {
+                "type": "error", "message": "The Final Blow requires spending a Spark on this roll.",
+            })
+            return
 
     # PHB III.3: Press costs Endurance (facet.yaml combat.press.endurance_cost)
     if press:
@@ -611,6 +738,20 @@ async def _handle_strike(
     offense_mod = combat_module.offense_modifier(
         character.posture or "measured", character.conditions, session.ruleset,
     ) or 0
+
+    # B4 Q1 (TD-9): the MM's declared label composes with at most one
+    # character-side Technique step — declared label first, step second
+    # (combat.apply_character_difficulty_step is the rule's only home).
+    difficulty, technique_step = _apply_difficulty_step(
+        character, difficulty_declared,
+        {
+            "skill_id": skill_id,
+            "weapon_category": weapon_category,
+            "weapon_type": weapon_type,
+            "declared_technique_ids": msg.get("declared_technique_ids"),
+        },
+        session.ruleset,
+    )
 
     request = RollRequest(
         attribute_id=attribute_id,
@@ -642,6 +783,16 @@ async def _handle_strike(
     if skill_id and skill_id in character.skills:
         character.skills_used_this_session.add(skill_id)
 
+    # TD-14: Final Blow fires on 7+ (both success tiers, per the BRIEF) —
+    # never on a 6- failure. Firing only *offers* the removal; it does not
+    # touch any enemy and does not mark the Technique used. That happens
+    # only in `_handle_final_blow_confirm`, gated to the MM.
+    final_blow_available = bool(
+        final_blow_requested
+        and sparks_to_spend >= 1          # the Spark was actually paid, not just requested
+        and result_dict["outcome"] in ("full_success", "partial_success")
+    )
+
     session.save_character_to_disk(player_name)
     await manager.broadcast(session_id, {
         "type": "strike_result",
@@ -652,6 +803,10 @@ async def _handle_strike(
         "posture": character.posture,
         "endurance_remaining": character.endurance_current,
         "sparks_remaining": character.sparks,
+        "weapon_category": weapon_category,
+        "weapon_type": weapon_type,
+        "technique_step": technique_step,
+        "final_blow_available": final_blow_available,
     })
 
 
@@ -717,15 +872,27 @@ async def _handle_react(
 
     # Active reactions (dodge/parry) require a roll
     roll_result = None
+    technique_step = None
     if reaction in ("dodge", "parry"):
         attr_id = "dexterity" if reaction == "dodge" else "strength"
         skill_id = None if reaction == "dodge" else "combat"
+        difficulty_declared = str(msg.get("difficulty", "Standard"))
+        # B4 Q1 (TD-9): same composition as Strike/roll — declared label
+        # first, at most one character-side Technique step second.
+        difficulty, technique_step = _apply_difficulty_step(
+            character, difficulty_declared,
+            {
+                "skill_id": skill_id,
+                "declared_technique_ids": msg.get("declared_technique_ids"),
+            },
+            session.ruleset,
+        )
         request = RollRequest(
             attribute_id=attr_id,
             attribute_rating=character.attributes.get(attr_id, 2),
             skill_id=skill_id,
             skill_rank_id=character.skills[skill_id].rank if skill_id and skill_id in character.skills else None,
-            difficulty_label=str(msg.get("difficulty", "Standard")),
+            difficulty_label=difficulty,
             description=f"{reaction} reaction",
         )
         roll = resolve_roll(request, session.ruleset)
@@ -744,6 +911,7 @@ async def _handle_react(
         "endurance_cost": cost,
         "endurance_remaining": character.endurance_current,
         "roll": roll_result,
+        "technique_step": technique_step,
     })
 
 
@@ -1268,7 +1436,9 @@ async def _handle_spawn_enemy(msg: dict, session, session_id: str) -> None:
     from app.game.enemy import Enemy
 
     enemy_id = str(msg.get("enemy_id", ""))
-    instance_name = str(msg.get("instance_name", ""))
+    # An explicit JSON null must not become the string "None" and rename the
+    # enemy — any client that sends the key unset would lose the stat block's name.
+    instance_name = str(msg.get("instance_name") or "")
 
     # Try loading from library first
     library_enemy = session.enemy_library.get(enemy_id)
@@ -1417,6 +1587,79 @@ async def _handle_enemy_strike(websocket, msg: dict, session, session_id: str) -
         "defeated": result.defeated,
         "mook_removed": False,
         "conditions": list(enemy.conditions),
+    })
+
+    if result.phase_index is not None:
+        await manager.broadcast(session_id, {
+            "type": "enemy_phase_change",
+            "enemy_id": tracker_key,
+            "phase_index": result.phase_index,
+            "description": enemy.phases[result.phase_index].description,
+        })
+
+
+async def _handle_final_blow_confirm(msg: dict, session, session_id: str) -> None:
+    """MM confirms a Final Blow removal offered by a Strike (B4 Q3, TD-14).
+
+    The Strike handler (`_handle_strike`) only *offers* the removal via
+    `final_blow_available` on the roll — it never touches an enemy and
+    never marks the Technique used. This handler is the commit: MM-gated
+    at dispatch, per DESIGN §4 ("auto-apply governs difficulty steps, not
+    actor removal — these are different questions"). It resolves the
+    removal through `combat.apply_final_blow_removal`, the canonical
+    defeat path (P11 invariant, TD-13), and only *here* does the once-
+    per-session use actually get recorded — a Strike that offered Final
+    Blow but was never confirmed leaves the Technique available.
+    """
+    player_name = str(msg.get("player", ""))
+    tracker_key = str(msg.get("tracker_key", ""))
+
+    character = session.characters.get(player_name)
+    if not character:
+        await manager.broadcast(session_id, {
+            "type": "error", "message": f"No character '{player_name}'.",
+        })
+        return
+
+    enemy = session.active_enemies.get(tracker_key)
+    if not enemy:
+        await manager.broadcast(session_id, {
+            "type": "error", "message": f"No active enemy with key '{tracker_key}'.",
+        })
+        return
+
+    if "the_final_blow" not in character.techniques:
+        await manager.broadcast(session_id, {
+            "type": "error", "message": "The Final Blow is not unlocked.",
+        })
+        return
+    if "the_final_blow" in character.techniques_used_this_session:
+        await manager.broadcast(session_id, {
+            "type": "error", "message": "The Final Blow has already been used this session.",
+        })
+        return
+
+    before = enemy.resolve_current if enemy.resolve_current is not None else enemy.resolve
+    result = combat_module.apply_final_blow_removal(
+        before, phase_thresholds=[p.resolve_threshold for p in enemy.phases] or None,
+    )
+    enemy.resolve_current = result.resolve_current
+    character.techniques_used_this_session.append("the_final_blow")
+    session.save_character_to_disk(player_name)
+
+    await manager.broadcast(session_id, {
+        "type": "enemy_updated",
+        "tracker_key": tracker_key,
+        "resolve_current": result.resolve_current,
+        "depletion": result.depletion,
+        "defeated": result.defeated,
+        "mook_removed": False,
+        "conditions": list(enemy.conditions),
+        # Distinguishes this event from an ordinary enemy_strike defeat
+        # (DESIGN §4 / TD-13's "distinguishable in the transcript").
+        "cause": result.cause,
+        "player": player_name,
+        "technique_id": "the_final_blow",
     })
 
     if result.phase_index is not None:

--- a/software/app/facets/schema.py
+++ b/software/app/facets/schema.py
@@ -83,6 +83,42 @@ class SkillDef(BaseModel):
 # Techniques
 # ---------------------------------------------------------------------------
 
+class StepTriggerDef(BaseModel):
+    """The condition under which a Technique's `difficulty_step` fires (B4 Q1,
+    DESIGN_technique_difficulty.md §2.3).
+
+    Two kinds:
+        "auto": the app evaluates the trigger itself from roll context data it
+                already holds (e.g. `weapon_category`), and the step applies
+                without asking the player — the roll banner shows it happened.
+        "declared": the trigger is a fictional judgement call no data can
+                settle (e.g. "an unexpected angle of attack"), so the player
+                toggles it on the roll.
+
+    Fields:
+        kind: "auto" | "declared".
+        match: For "auto" only — the roll-context field name to check
+               (e.g. "weapon_category", "hazard_type", "knowledge_field",
+               "skill_id"). Unused (None) for "declared".
+        against: For "auto" only — what `match`'s context value must equal
+                 to fire. Either the literal string "choice" (compare
+                 against the character's `technique_choices[technique_id]`)
+                 or a literal value to compare against directly (e.g.
+                 Steady Hand's `skill_id == "finesse"`). Unused (None) for
+                 "declared".
+    """
+
+    kind: Literal["auto", "declared"]
+    match: str | None = None
+    against: str | None = None
+    #: When set, the trigger only fires on a roll using this skill. The
+    #: book scopes some Techniques to one skill — Acclimated is "Endurance
+    #: rolls against your chosen hardship", Field of Mastery is "Lore rolls
+    #: that fall within your chosen field". Without this conjunct the engine
+    #: implements a broader rule than the printed one.
+    requires_skill: str | None = None
+
+
 class TechniqueDef(BaseModel):
     """A single unlockable Technique in a Facet's Technique tree.
 
@@ -110,6 +146,47 @@ class TechniqueDef(BaseModel):
                         side effect of the prerequisite chain, since the chain is not
                         guaranteed to route through the Facet's domain-granting
                         Technique (sync report H-2).
+        difficulty_step: "easier" | "harder" | None (B4 Q1). If set, this
+                        Technique — once unlocked and its `step_trigger`
+                        satisfied — shifts a roll's declared difficulty one
+                        rung. Composed by `app.game.combat
+                        .apply_character_difficulty_step`, never applied
+                        inline by a caller. Optional and defaults to None so
+                        every Technique that predates B4 Q1 parses unchanged.
+        step_trigger: The `StepTriggerDef` gating `difficulty_step`. Required
+                        in practice whenever `difficulty_step` is set, but not
+                        enforced by the schema — a Technique with a step and
+                        no trigger simply never fires (see combat.py).
+        choices: The machine-readable option list for a `has_choice` Technique
+                        that is not domain-granting (DESIGN §8 / TD-19)  —
+                        e.g. Weapon Mastery's `blades`/`blunt`/`polearms`/
+                        `unarmed`. `choice_prompt` stays the human-readable
+                        label printed in the book; `choices` is what the
+                        client renders a picker from and what
+                        `technique_choices[tech_id]` is expected to hold.
+                        Optional and defaults to `None` so every Technique
+                        that predates TD-19 (including domain-granting ones,
+                        which build their option list from the domain
+                        catalog instead) parses unchanged. For Techniques
+                        whose fiction is deliberately open-ended (Field of
+                        Mastery), the list is suggestions, not a closed set —
+                        nothing in the schema or the engine enforces
+                        membership (INV-8).
+        removes_target_from_conflict: True only for *The Final Blow* (B4 Q3
+                        / TD-12). Marks a Technique as a **licensed
+                        override**, not a rider — III.3's "riders never
+                        defeat an enemy on their own" governs rider
+                        Conditions and does not apply to a Technique
+                        carrying this flag. The engine resolves its use as
+                        a defeat event through the canonical defeat path
+                        (`combat.apply_final_blow_removal`), never a raw
+                        `resolve_current` write (P11 invariant). A flag,
+                        not a mechanism — kept explicit and greppable so
+                        overrides stay countable (exactly one Technique
+                        this cycle; see
+                        `test_facets_schema.py::TestFinalBlowOverrideFlag`).
+                        Optional and defaults to `False` so every other
+                        Technique parses unchanged.
     """
 
     id: str
@@ -122,6 +199,10 @@ class TechniqueDef(BaseModel):
     grants_prismatic_domain: bool = False
     grants_secondary_domain: bool = False
     requires_domain: str | None = None
+    difficulty_step: Literal["easier", "harder"] | None = None
+    step_trigger: StepTriggerDef | None = None
+    choices: list[str] | None = None
+    removes_target_from_conflict: bool = False
 
 
 class TierDef(BaseModel):
@@ -611,6 +692,14 @@ class EquipmentDef(BaseModel):
     """Equipment reference data (PHB IV.1)."""
 
     weapon_categories: dict[str, WeaponCategoryDef] = Field(default_factory=dict)
+    # DESIGN §8 (TD-18): the *fictional* weapon vocabulary — blades/blunt/
+    # polearms/unarmed — that Weapon Mastery (II.4a) masters. Orthogonal to
+    # `weapon_categories` above, which is the *mechanical* vocabulary that
+    # sets a Strike's attribute. A longsword is `standard` category and
+    # `blades` type at once; the two lists are not meant to line up. No
+    # ranged entry exists here because Weapon Mastery has no option covering
+    # ranged weapons (content gap, docs/TODO.md T8 — not fixed in code).
+    weapon_types: list[str] = Field(default_factory=list)
 
 
 class DeathDef(BaseModel):

--- a/software/app/game/combat.py
+++ b/software/app/game/combat.py
@@ -119,6 +119,26 @@ class ResolveDamageResult:
 
 
 @dataclass
+class FinalBlowResult:
+    """Result of `apply_final_blow_removal` (B4 Q3 — *The Final Blow*).
+
+    Deliberately its own type, not a reuse of `ResolveDamageResult`: the two
+    must be distinguishable at the type level, not just by field values, so
+    a transcript or a future sim series can tell a licensed-override removal
+    apart from an ordinary Strike defeating an enemy at 0 Resolve on sight —
+    without relying on a caller remembering to check a `cause` string.
+    `cause` is carried anyway, for callers (the WS broadcast, the transcript
+    log) that want a machine-readable label rather than a type check.
+    """
+
+    resolve_current: int  # always 0 — the target is removed
+    depletion: int  # however much Resolve this removal actually took off, for the transcript
+    defeated: bool  # always True
+    phase_index: Optional[int]  # index into the caller's `phase_thresholds`, or None
+    cause: str = "final_blow"  # distinguishes this event from an ordinary Resolve-0 defeat
+
+
+@dataclass
 class ArmorDowngradeResult:
     """Result of `armor_downgrade` (D2 — PC per-scene downgrade budget)."""
 
@@ -481,6 +501,54 @@ def apply_resolve_damage(
     )
 
 
+def apply_final_blow_removal(
+    resolve_current: int,
+    phase_thresholds: Optional[list[int]] = None,
+) -> FinalBlowResult:
+    """Resolve *The Final Blow*'s target removal (B4 Q3) as a defeat event
+    through the canonical defeat path — never a raw `resolve_current = 0`
+    write.
+
+    P11 invariant: every `resolve_current` mutation routes through
+    `phase_crossed`, the same primitive `apply_resolve_damage` uses to
+    detect a Boss phase crossing from an ordinary Strike. A raw write would
+    skip that call and could silently miss a phase change the removal
+    triggers in passing (e.g. a Boss whose Reduced Mode threshold sits above
+    0) — bypassing phase logic and corrupting anything reading the
+    transcript afterward. This function is *not* `apply_resolve_damage`
+    with a bigger number: it works on any target regardless of remaining
+    Resolve (Bosses included, per B4/the BRIEF's Q3 ruling — the removal is
+    a licensed override, not depletion), and it returns the distinct
+    `FinalBlowResult` type so a capstone removal can never be mistaken for,
+    or silently merged with, an ordinary Resolve-0 defeat.
+
+    The once-per-session gate, the Spark spend, and the "succeed" (7+)
+    requirement are the caller's job (`websocket._handle_*`) — this
+    function only resolves the mechanical consequence once a caller has
+    already established the Technique fires. It also does not decide
+    whether the removal *commits*: MM confirmation gates that at the
+    caller, because auto-apply (B4's UX ruling) governs difficulty steps,
+    not actor removal.
+
+    Args:
+        resolve_current: The target's Resolve immediately before removal.
+        phase_thresholds: The target's `PhaseDef.resolve_threshold` values,
+            in definition order, or `None`/empty for a target with no
+            phases (Mooks, Named NPCs, most Bosses outside a phase block).
+
+    Returns:
+        A `FinalBlowResult` with `resolve_current=0`, `defeated=True`, and
+        `phase_index` set if the drop to 0 crosses a phase boundary.
+    """
+    new_resolve = 0
+    return FinalBlowResult(
+        resolve_current=new_resolve,
+        depletion=max(0, resolve_current),
+        defeated=True,
+        phase_index=phase_crossed(resolve_current, new_resolve, phase_thresholds),
+    )
+
+
 def maneuver_target_difficulty(outcome: str, base_difficulty: str, ruleset) -> str:
     """Effect of a Maneuver's outcome on rolls against the target (III.3):
     a 10+ makes rolls against the target Easy (until the situation
@@ -622,6 +690,124 @@ def apply_condition(
 
     conditions.append(condition)
     return ConditionResult(applied=True, condition=condition, tier=tier, broken=False)
+
+
+# ---------------------------------------------------------------------------
+# Difficulty composition — B4 Q1 (DESIGN_technique_difficulty.md §2.2)
+# ---------------------------------------------------------------------------
+
+def apply_character_difficulty_step(
+    declared_label: str,
+    character,
+    context: dict,
+    ruleset,
+) -> tuple[str, Optional[str]]:
+    """Compose the MM's declared difficulty label with at most one
+    character-side Technique step (DECISIONS.md B4, Q1).
+
+    This lives here, not in `websocket.py` or `tools/combat_sim.py`, because
+    it is a rule: `CLAUDE.md`'s iron law is that the simulator may only
+    *drive* `combat.py`, never carry its own copy of a rule, and this project
+    has already been burned once by exactly that divergence (DECISIONS R1).
+    Every caller — the three WS handlers this cycle wires (strike, generic
+    roll, reaction) and any future sim series — must call this function
+    rather than re-deriving a step inline.
+
+    **Order** (non-negotiable, B4): `declared_label` is the MM's situational
+    call, already resolved, and is never second-guessed here. A character-side
+    step applies to it second. The ladder then clamps via
+    `engine._step_difficulty_easier`/`_harder`, which already saturate at
+    the four-rung ladder's ends (Easy stays Easy; Very Hard stays Very Hard)
+    — those are ladder primitives; this function only composes them.
+
+    **Guardrail**: character-side steps never stack, whatever their source —
+    at most one per roll. `context` may make several unlocked Techniques
+    qualify at once; only one step is ever applied. Precedence is
+    deterministic so the roll banner names a stable Technique: a
+    player-declared Technique beats an auto one, then lowest Technique id.
+
+    Only Techniques in `character.techniques` (i.e. actually unlocked) are
+    eligible — an un-unlocked Technique's `difficulty_step` never fires,
+    even if its trigger would otherwise match.
+
+    Args:
+        declared_label: The MM's already-resolved situational difficulty.
+        character: Anything exposing `.techniques` (list[str], unlocked
+            Technique ids) and `.technique_choices` (dict[str, str]).
+        context: Roll facts the trigger evaluates against — `skill_id`,
+            `weapon_category`, `weapon_type`, `hazard_type`,
+            `knowledge_field`, and `declared_technique_ids` (the player's
+            toggles for declared-kind Techniques). A field this dict omits
+            simply means no auto trigger keyed on it can fire — it is not
+            an error. `weapon_category` and `weapon_type` are orthogonal
+            (DESIGN §8): the former is the mechanical IV.1 taxonomy that
+            sets a Strike's attribute, the latter the fictional taxonomy
+            *Weapon Mastery* masters (blades/blunt/polearms/unarmed) — this
+            function does not know or care which trigger reads which key,
+            it only compares `context[trigger.match]`.
+        ruleset: A `MergedRuleset` (or anything exposing `get_technique()`
+            and the attributes `_step_difficulty_easier`/`_harder` read).
+
+    Returns:
+        `(final_label, applied_technique_id)` — `applied_technique_id` is
+        `None` when no Technique fired, so the roll banner and transcript
+        can distinguish an unmodified roll from a stepped one (DESIGN §2.7).
+    """
+    # Client-supplied; a non-iterable here used to raise straight through the
+    # dispatch loop and disconnect the sender.
+    raw_declared = context.get("declared_technique_ids") or []
+    if isinstance(raw_declared, (str, bytes)) or not isinstance(raw_declared, (list, tuple, set)):
+        raw_declared = []
+    declared_ids = {str(x) for x in raw_declared}
+    # (precedence_rank, technique_id): rank 0 = player-declared, rank 1 = auto.
+    # Sorting by this tuple gives "declared beats auto, then lowest id" in one step.
+    candidates: list[tuple[int, str]] = []
+
+    for tech_id in character.techniques:
+        tech_def = ruleset.get_technique(tech_id)
+        if tech_def is None or tech_def.difficulty_step is None or tech_def.step_trigger is None:
+            continue
+
+        trigger = tech_def.step_trigger
+        if trigger.kind == "declared":
+            if tech_id not in declared_ids:
+                continue
+            candidates.append((0, tech_id))
+        elif trigger.kind == "auto":
+            # A Technique the book scopes to one skill only fires on that skill.
+            # Without this, Acclimated ("Endurance rolls against your chosen
+            # hardship") and Field of Mastery ("Lore rolls within your chosen
+            # field") stepped any roll that carried the matching context string —
+            # the engine implementing a wider rule than the printed one.
+            if trigger.requires_skill and context.get("skill_id") != trigger.requires_skill:
+                continue
+            match_field = trigger.match
+            if not match_field or match_field not in context:
+                continue
+            context_value = context[match_field]
+            if context_value is None:
+                continue
+            if trigger.against == "choice":
+                expected = character.technique_choices.get(tech_id)
+            else:
+                expected = trigger.against
+            if expected is None or context_value != expected:
+                continue
+            candidates.append((1, tech_id))
+
+    if not candidates:
+        return declared_label, None
+
+    candidates.sort()
+    _, applied_id = candidates[0]
+    applied_def = ruleset.get_technique(applied_id)
+
+    if applied_def.difficulty_step == "easier":
+        final_label = _engine._step_difficulty_easier(declared_label, ruleset)
+    else:
+        final_label = _engine._step_difficulty_harder(declared_label, ruleset)
+
+    return final_label, applied_id
 
 
 def end_exchange(conditions: list[str], ruleset) -> list[str]:

--- a/software/app/static/index.html
+++ b/software/app/static/index.html
@@ -253,6 +253,10 @@
                 </select>
                 <label for="play-roll-description">Description (optional)</label>
                 <input type="text" id="play-roll-description" placeholder="What are you attempting?">
+                <label for="play-roll-hazard-type">Hazard type (optional — Acclimated)</label>
+                <input type="text" id="play-roll-hazard-type" placeholder="e.g. extreme cold">
+                <label for="play-roll-knowledge-field">Knowledge field (optional — Field of Mastery)</label>
+                <input type="text" id="play-roll-knowledge-field" placeholder="e.g. arcane theory">
                 <div class="inline-note">
                   10+ full success · 7-9 success with a cost · 6- things go wrong, but the story moves.
                   Stage Sparks on the pips above to add dice before you roll.
@@ -363,6 +367,23 @@
                   </p>
                   <label for="strike-target">Target</label>
                   <select id="strike-target"></select>
+                  <label for="strike-weapon-category">Weapon Category (optional)</label>
+                  <select id="strike-weapon-category" onchange="onStrikeWeaponCategoryChange()">
+                    <option value="">-- none --</option>
+                    <option value="heavy">Heavy (Strength)</option>
+                    <option value="standard">Standard (Strength or Dexterity)</option>
+                    <option value="light">Light (Dexterity)</option>
+                    <option value="ranged">Ranged (Dexterity)</option>
+                    <option value="unarmed">Unarmed (Strength or Dexterity)</option>
+                  </select>
+                  <label for="strike-weapon-type">Weapon Type (optional, for Weapon Mastery)</label>
+                  <select id="strike-weapon-type">
+                    <option value="">-- none --</option>
+                    <option value="blades">Blades</option>
+                    <option value="blunt">Blunt</option>
+                    <option value="polearms">Polearms</option>
+                    <option value="unarmed">Unarmed</option>
+                  </select>
                   <label for="strike-attribute">Attribute</label>
                   <select id="strike-attribute"></select>
                   <label for="strike-skill">Skill (optional)</label>
@@ -376,6 +397,10 @@
                   </select>
                   <label class="checkbox-inline" style="margin:6px 0;">
                     <input type="checkbox" id="strike-press"> Press — spend 1 Endurance for +1d6, drop lowest
+                  </label>
+                  <label class="checkbox-inline" style="margin:6px 0;">
+                    <input type="checkbox" id="strike-final-blow">
+                    The Final Blow — once per session, spend a Spark; on 7+ the target is removed (MM confirms)
                   </label>
                   <div class="inline-note">
                     Sparks staged on your sheet above apply to this Strike too.

--- a/software/app/static/js/builder.js
+++ b/software/app/static/js/builder.js
@@ -179,8 +179,21 @@ async function selectTechnique(techId) {
  * Offer the legal choices for a Technique. For the domain-granting Techniques
  * that means the right domain list: Ascendant Domain takes prismatic territories,
  * Second Domain takes standard ones only (PHB II.4b/II.4c).
+ *
+ * TD-20 (DESIGN §8): non-domain `has_choice` Techniques — Weapon Mastery,
+ * Acclimated, Field of Mastery — used to fall through to the domain logic
+ * below and get offered the character's primary Facet's *domain* names as
+ * candidate weapon types, hardships, or fields of knowledge, which is not
+ * merely wrong but doesn't even overlap the Technique's real vocabulary.
+ * TD-19 gave these three Techniques a `choices` list of their own in
+ * facet.yaml; when a Technique carries one, it is authoritative and the
+ * domain-list branch never runs for it.
  */
 function pickTechniqueChoice(def) {
+  if (def.choices && def.choices.length) {
+    return pickFromChoicesList(def);
+  }
+
   const magic = (state.ruleset && state.ruleset.magic) || {};
   const facetForDomains = def.requires_domain || state.character.primary_facet;
   const list = (facetForDomains === 'mind' ? magic.mind_domains : magic.soul_domains) || [];
@@ -206,6 +219,31 @@ function pickTechniqueChoice(def) {
     def.name || def.id,
     def.choice_prompt || 'Choose a domain.',
     options.map(d => ({ value: d.id, label: `${d.name} (${d.type})` })));
+}
+
+/**
+ * Picker for a non-domain Technique's `choices` list (TD-19/TD-20).
+ *
+ * Field of Mastery is deliberately open-ended in the fiction (II.4a: "or
+ * another domain with MM approval") — nothing gates membership (INV-8) —
+ * so it alone gets an "Other..." entry that drops into free text via
+ * `promptDialog`. Weapon Mastery and Acclimated are closed sets (the book
+ * lists exactly four/four options each) and offer only what `choices` says.
+ */
+async function pickFromChoicesList(def) {
+  const OTHER = '__other__';
+  const options = def.choices.map(c => ({ value: c, label: c }));
+  if (def.id === 'field_of_mastery') {
+    options.push({ value: OTHER, label: 'Other (type your own)...' });
+  }
+  const picked = await selectDialog(
+    def.name || def.id,
+    def.choice_prompt || 'Choose an option.',
+    options);
+  if (picked === OTHER) {
+    return promptDialog('Field of Mastery', 'e.g. cartography, herbalism...', '');
+  }
+  return picked;
 }
 
 // ---------------------------------------------------------------------------

--- a/software/app/static/js/play.js
+++ b/software/app/static/js/play.js
@@ -231,8 +231,14 @@ function performRoll() {
 
   const diffEl = document.getElementById('play-difficulty-select');
   const descEl = document.getElementById('play-roll-description');
+  const hazardEl = document.getElementById('play-roll-hazard-type');
+  const fieldEl = document.getElementById('play-roll-knowledge-field');
   const difficulty = diffEl ? diffEl.value : 'Standard';
   const description = descEl ? descEl.value.slice(0, 200) : '';
+  // Optional (B4 Q1, TD-8): absent unless the player names a hardship/field,
+  // in which case Acclimated/Field of Mastery may auto-apply a step.
+  const hazardType = hazardEl && hazardEl.value.trim() ? hazardEl.value.trim() : null;
+  const knowledgeField = fieldEl && fieldEl.value.trim() ? fieldEl.value.trim() : null;
 
   sendWS({
     type: 'roll',
@@ -241,6 +247,8 @@ function performRoll() {
     difficulty,
     sparks_spent: state.sparksToSpend,
     description,
+    hazard_type: hazardType,
+    knowledge_field: knowledgeField,
   });
 
   state.sparksToSpend = 0;
@@ -297,8 +305,17 @@ function buildRollResultHtml(msg, roll) {
 
   const whoStr = msg.player === state.playerName ? 'You' : (msg.character_name || msg.player);
 
+  // B4 Q1 (TD-10, DESIGN §2.7): auto-apply is only legible because the
+  // banner shows both moves — the MM's declared label AND the Technique
+  // that stepped it. When no Technique fired, msg.technique_step is absent
+  // (or null) and this renders nothing, leaving the banner unchanged.
+  const stepHtml = msg.technique_step
+    ? `<div class="technique-step-banner" style="font-size:0.8rem;color:var(--gold);margin-bottom:4px;">${escapeHtml(String(msg.technique_step.from))} (MM) → ${escapeHtml(String(msg.technique_step.to))} (${escapeHtml(String(msg.technique_step.technique_name))})</div>`
+    : '';
+
   return `
     <div style="font-size:0.8rem;color:var(--text-dim);margin-bottom:4px;">${whoStr} rolled ${roll.attribute_id}${roll.skill_id ? ' + ' + roll.skill_id : ''}${roll.difficulty !== 'Standard' ? ' [' + roll.difficulty + ']' : ''}${roll.sparks_spent > 0 ? ' x' + roll.sparks_spent : ''}</div>
+    ${stepHtml}
     <div class="dice-display">${diceHtml}</div>
     <div class="roll-total">${roll.total}</div>
     <div class="roll-outcome-label">${roll.outcome_label}</div>
@@ -502,6 +519,15 @@ function enemyStrikeOutcome(trackerKey, outcome) {
   sendWS({ type: 'enemy_strike', tracker_key: trackerKey, outcome });
 }
 
+/**
+ * TD-14 (B4 Q3): commits a Final Blow removal offered by a Strike. This is
+ * the MM confirmation DESIGN §4 requires before an actor is deleted from
+ * the encounter — auto-apply covers difficulty steps only, never this.
+ */
+function confirmFinalBlow(playerName, trackerKey) {
+  sendWS({ type: 'final_blow_confirm', player: playerName, tracker_key: trackerKey });
+}
+
 /** Manual correction — an undo, not a rule. Stays on `enemy_update`. */
 function enemyAdjustResolve(trackerKey, delta) {
   const enemy = state.activeEnemies[trackerKey];
@@ -550,8 +576,16 @@ function onEnemyUpdated(msg) {
   // infers either.
   if (msg.defeated) {
     delete state.activeEnemies[msg.tracker_key];
-    addSystemChat(`${name} is defeated.`);
-    notify(`${name} is defeated.`, 'success');
+    // TD-14/TD-13 (B4 Q3): a Final Blow removal is a licensed override, not
+    // Resolve depletion — `cause` distinguishes it in the log from an
+    // ordinary Resolve-0 defeat, same as it does in the transcript.
+    if (msg.cause === 'final_blow') {
+      addSystemChat(`${name} is removed from the conflict — The Final Blow.`);
+      notify(`${name} is removed from the conflict — The Final Blow.`, 'success');
+    } else {
+      addSystemChat(`${name} is defeated.`);
+      notify(`${name} is defeated.`, 'success');
+    }
   } else if (msg.depletion) {
     addSystemChat(`${name}: −${msg.depletion} Resolve (now ${msg.resolve_current}).`);
   }
@@ -1055,16 +1089,52 @@ function declarePosture() {
   sendWS({ type: 'declare_posture', posture });
 }
 
+/**
+ * TD-7 (B4 Q1 side benefit, IV.1:13-19): the weapon category picker sets the
+ * Strike attribute *as a default only* — the player can still override it,
+ * because the engine stays permissive on which attribute/skill a Strike uses
+ * (INV-8) and the picker must never become a gate on that.
+ */
+function onStrikeWeaponCategoryChange() {
+  const catEl = document.getElementById('strike-weapon-category');
+  const attrEl = document.getElementById('strike-attribute');
+  if (!catEl || !attrEl) return;
+  const category = catEl.value;
+  const categories = (state.ruleset && state.ruleset.equipment && state.ruleset.equipment.weapon_categories) || {};
+  const def = categories[category];
+  if (def && def.attributes && def.attributes.length) {
+    attrEl.value = def.attributes[0];
+  }
+}
+
 function performStrike() {
   const target = (document.getElementById('strike-target').value || '').trim();
   const attrId = document.getElementById('strike-attribute').value;
   const skillId = document.getElementById('strike-skill').value || null;
   const difficulty = document.getElementById('strike-difficulty').value;
   const press = document.getElementById('strike-press').checked;
+  const weaponCategoryEl = document.getElementById('strike-weapon-category');
+  const weaponCategory = weaponCategoryEl && weaponCategoryEl.value ? weaponCategoryEl.value : null;
+  // TD-18 (DESIGN §8): weapon_type is the orthogonal, fictional vocabulary
+  // (blades/blunt/polearms/unarmed) Weapon Mastery masters — separate from
+  // weapon_category above, which only defaults the attribute picker.
+  const weaponTypeEl = document.getElementById('strike-weapon-type');
+  const weaponType = weaponTypeEl && weaponTypeEl.value ? weaponTypeEl.value : null;
+  // TD-14 (B4 Q3): a player toggle, not an auto-apply — Final Blow deletes
+  // an actor from the encounter, so unlike a difficulty step it always
+  // needs the player's explicit ask and the MM's explicit confirmation
+  // (DESIGN §4). The server enforces once-per-session, Combat-roll, and
+  // Spark-spent; this checkbox only carries the player's declaration.
+  const finalBlowEl = document.getElementById('strike-final-blow');
+  const finalBlow = !!(finalBlowEl && finalBlowEl.checked);
 
   if (!target) { notify('Choose a target.', 'warn'); focusElement('strike-target'); return; }
   if (press && (state.character.endurance_current || 0) < 1) {
     notify('No Endurance left to Press.', 'warn');
+    return;
+  }
+  if (finalBlow && state.sparksToSpend < 1) {
+    notify('The Final Blow requires spending a Spark on this roll.', 'warn');
     return;
   }
 
@@ -1076,7 +1146,11 @@ function performStrike() {
     difficulty,
     press,
     sparks_spent: state.sparksToSpend,
+    weapon_category: weaponCategory,
+    weapon_type: weaponType,
+    final_blow: finalBlow,
   });
+  if (finalBlowEl) finalBlowEl.checked = false;
   state.sparksToSpend = 0;
   renderPlaySparkCounter();
 }
@@ -1230,14 +1304,48 @@ function onStrikeResult(msg) {
 
   // Show result box for own strikes
   if (msg.attacker === state.playerName) {
-    showRollResultBox({ player: msg.attacker, character_name: attackerName }, roll);
+    showRollResultBox({ player: msg.attacker, character_name: attackerName, technique_step: msg.technique_step }, roll);
   }
 
   // Prompt the MM to apply the outcome. How much it costs is the engine's
-  // business — the tracker's Hit buttons send the outcome, not a number.
+  // business — this sends the outcome, not a number.
+  //
+  // The prompt used to say "apply it on the enemy tracker" and leave the MM to
+  // find the row. A subagent playtest (playtest/08_npc_variance, F4) showed the
+  // real cost of that gap: a player rolled a full success on a Mook, said "that
+  // one should be gone", and it was still standing in the engine. Between the
+  // roll and the MM's click, the table's model of the fight and the engine's
+  // state disagree. When the target is a tracked enemy, apply it from here.
   if (state.role === 'mm' && msg.target && roll.outcome !== 'failure') {
-    notify(`${attackerName} hits ${msg.target} — ${roll.outcome_label}. `
-      + 'Apply it on the enemy tracker.', 'info', { duration: 7000 });
+    const tracked = state.activeEnemies && state.activeEnemies[msg.target];
+    const headline = `${attackerName} hits ${msg.target} — ${roll.outcome_label}.`;
+    if (tracked) {
+      notify(headline, 'info', {
+        duration: 12000,
+        key: 'apply-strike',
+        action: 'Apply',
+        onAction: () => enemyStrikeOutcome(msg.target, roll.outcome),
+      });
+    } else {
+      // Not in the tracker — a PvP Strike or an untracked target. Nothing to apply.
+      notify(`${headline} Apply it on the enemy tracker.`, 'info', { duration: 7000 });
+    }
+  }
+
+  // TD-14 (B4 Q3): the server only *offers* Final Blow on the roll — the
+  // removal never touches an enemy until the MM explicitly confirms it.
+  if (state.role === 'mm' && msg.final_blow_available && msg.target) {
+    const tracked = state.activeEnemies && state.activeEnemies[msg.target];
+    if (tracked) {
+      notify(`${attackerName} lands The Final Blow on ${msg.target} — confirm the removal?`, 'info', {
+        duration: 20000,
+        key: 'confirm-final-blow',
+        action: 'Confirm Final Blow',
+        onAction: () => confirmFinalBlow(msg.attacker, msg.target),
+      });
+    } else {
+      notify(`${attackerName} lands The Final Blow, but ${msg.target} is not in the enemy tracker.`, 'info', { duration: 7000 });
+    }
   }
 }
 
@@ -1260,7 +1368,12 @@ function onReactResult(msg) {
 
   const reactorName = (state.allCharacters[msg.player] || {}).name || msg.player;
   const rollStr = roll ? ' — ' + roll.outcome_label : '';
-  addSystemChat(reactorName + ' reacts: ' + msg.reaction + ' (cost ' + msg.endurance_cost + ' End)' + rollStr);
+  // B4 Q1 (TD-10): reactions have no roll-result box, so the banner text
+  // goes in the chat line instead — same two moves, same visibility.
+  const stepStr = msg.technique_step
+    ? ' [' + msg.technique_step.from + ' (MM) → ' + msg.technique_step.to + ' (' + msg.technique_step.technique_name + ')]'
+    : '';
+  addSystemChat(reactorName + ' reacts: ' + msg.reaction + ' (cost ' + msg.endurance_cost + ' End)' + rollStr + stepStr);
 }
 
 function onSupportResult(msg) {

--- a/software/tests/e2e/test_ui_flows.py
+++ b/software/tests/e2e/test_ui_flows.py
@@ -59,16 +59,29 @@ def live_server(tmp_path_factory):
         "PORT": str(port),
         "HOST": "127.0.0.1",
     }
+    # Log to a file, never to an undrained pipe. uvicorn logs every request at
+    # info level; with `stdout=PIPE` and nobody reading it, the 64KB OS pipe
+    # buffer filled about fifty tests in and the server BLOCKED ON WRITE —
+    # wedged, accepting no HTTP at all. It looked like flakiness in whichever
+    # test happened to be running at the time.
+    log_path = data_dir / "server.log"
+    log_file = log_path.open("wb")
     proc = subprocess.Popen(
         [sys.executable, "run.py"],
         cwd=SOFTWARE_DIR, env=env,
-        stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+        stdout=log_file, stderr=subprocess.STDOUT,
     )
+
+    def _server_log() -> str:
+        try:
+            return log_path.read_text(errors="replace")
+        except OSError:
+            return "(no server log)"
 
     base = f"http://127.0.0.1:{port}"
     for _ in range(100):
         if proc.poll() is not None:
-            pytest.fail(f"server exited early:\n{proc.stdout.read().decode(errors='replace')}")
+            pytest.fail(f"server exited early:\n{_server_log()}")
         try:
             with socket.create_connection(("127.0.0.1", port), timeout=0.2):
                 break
@@ -84,6 +97,7 @@ def live_server(tmp_path_factory):
         proc.wait(timeout=5)
     except subprocess.TimeoutExpired:
         proc.kill()
+    log_file.close()
 
 
 @pytest.fixture(scope="module")
@@ -156,10 +170,31 @@ def _login_mm(page, base, token):
     page.wait_for_timeout(300)
 
 
+def _delete_session(base: str, token: str, session_id: str) -> None:
+    """Best-effort teardown — a failure here must not mask a test result."""
+    import urllib.error
+    import urllib.request
+
+    request = urllib.request.Request(
+        f"{base.rstrip('/')}/api/sessions/{session_id}", method="DELETE",
+        headers={"Authorization": f"Bearer {token}"})
+    try:
+        urllib.request.urlopen(request, timeout=10).close()
+    except (urllib.error.URLError, OSError):
+        pass
+
+
 def _make_session_and_invite(page, name, player):
     page.fill("#new-session-name", name)
     page.click("button:has-text('Create Session')")
-    page.wait_for_timeout(600)
+    # Wait for the option, not for a fixed 600ms. The list re-render is async and
+    # the session list grows all run, so a sleep is a race by construction.
+    page.wait_for_function(
+        """expected => {
+            const select = document.getElementById('invite-session-id');
+            return !!select && [...select.options].some(o => o.textContent === expected);
+        }""",
+        arg=name, timeout=15000)
     page.select_option("#invite-session-id", label=name)
     page.fill("#invite-player-name", player)
     page.click("button:has-text('Generate Invite Link')")
@@ -194,6 +229,7 @@ def table(live_server, browser, errors, request, mm_token):
     _login_mm(mm, live_server, mm_token)
     session_name = f"E2E {request.node.name}"[:60]
     invite = _make_session_and_invite(mm, session_name, "Zahna")
+    session_id = mm.evaluate("() => state.sessionId")
 
     player = errors.attach(browser.new_page(viewport={"width": 1400, "height": 950}), "PLAYER")
     _join_and_build(player, invite, "Zahna")
@@ -202,6 +238,13 @@ def table(live_server, browser, errors, request, mm_token):
     yield mm, player
     mm.close()
     player.close()
+    # Delete the session. Every test in this module makes one against a shared
+    # server and nothing used to clean them up, so the dashboard's session list
+    # grew all run; past ~50 the MM's own list stopped rendering and later
+    # fixtures found an empty session picker. Bounding the accumulation is the
+    # actual fix — waiting longer for the list only moved the threshold.
+    if session_id:
+        _delete_session(live_server, mm_token, session_id)
 
 
 # ---------------------------------------------------------------------------
@@ -314,6 +357,131 @@ class TestCombatLoop:
             "#strike-target option", "els => els.map(e => e.textContent)")
         assert any("Harbor Thug" in t for t in targets)
 
+
+
+    def test_a_strike_on_a_tracked_enemy_can_be_applied_from_the_prompt(self, table):
+        """A Strike roll does not itself remove the enemy — the MM must apply
+        the outcome. The prompt used to say "apply it on the enemy tracker" and
+        leave them to find the row, so between the roll and the click the table
+        and the engine disagreed about whether the enemy was still standing.
+
+        Found by the subagent playtest, 2026-07-31 (F4): a player rolled a full
+        success on a Mook, said "that one should be gone", and it was not.
+        """
+        mm, player = table
+        mm.click("button[data-tab='builder']")
+        mm.wait_for_timeout(300)
+        mm.fill("#builder-enemy-name", "Harbor Thug")
+        mm.select_option("#builder-enemy-tier", "mook")
+        mm.click("button:has-text('Save to Library')")
+        mm.wait_for_timeout(600)
+        mm.click("button[data-tab='play']")
+        mm.wait_for_timeout(300)
+        mm.select_option("#play-spawn-enemy-select", "harbor_thug")
+        mm.click("button:has-text('Spawn')")
+        mm.wait_for_timeout(700)
+
+        mm.click("button:has-text('Start Combat')")
+        mm.wait_for_timeout(600)
+        player.wait_for_timeout(500)
+
+        # Drive the Strike through the socket so the test does not depend on
+        # the dice: any non-failure outcome must offer the MM an Apply.
+        tracker_key = mm.evaluate("() => Object.keys(state.activeEnemies)[0]")
+        assert tracker_key, "nothing in the enemy tracker to strike"
+        mm.evaluate(
+            """key => onStrikeResult({
+                attacker: 'Zahna', target: key,
+                roll: {dice_rolled: [6, 5], dice_kept: [6, 5], dice_sum: 11,
+                       attribute_modifier: 0, skill_modifier: 0,
+                       difficulty_modifier: 0, total: 11, outcome: 'full_success',
+                       outcome_label: 'Full Success', outcome_description: '',
+                       sparks_spent: 0},
+                endurance_remaining: 5, sparks_remaining: 3, press_used: false,
+            })""",
+            tracker_key)
+        mm.wait_for_timeout(400)
+
+        apply_button = mm.locator("#toast-host button:has-text('Apply')")
+        assert apply_button.count() == 1, "no one-click Apply on the Strike prompt"
+
+        apply_button.click()
+        mm.wait_for_timeout(800)
+
+        # A Mook taking a full success is removed outright — the engine's call.
+        remaining = mm.evaluate("() => Object.keys(state.activeEnemies)")
+        assert tracker_key not in remaining, "Apply did not reach the engine"
+
+    def test_a_strike_on_an_untracked_target_offers_no_apply(self, table):
+        """PvP and untracked targets have nothing to apply the outcome to, so
+        the prompt must stay advisory rather than offering a dead button."""
+        mm, player = table
+        mm.click("button:has-text('Start Combat')")
+        mm.wait_for_timeout(600)
+
+        mm.evaluate(
+            """() => onStrikeResult({
+                attacker: 'Zahna', target: 'Some Bystander',
+                roll: {dice_rolled: [6, 5], dice_kept: [6, 5], dice_sum: 11,
+                       attribute_modifier: 0, skill_modifier: 0,
+                       difficulty_modifier: 0, total: 11, outcome: 'full_success',
+                       outcome_label: 'Full Success', outcome_description: '',
+                       sparks_spent: 0},
+                endurance_remaining: 5, sparks_remaining: 3, press_used: false,
+            })""")
+        mm.wait_for_timeout(400)
+
+        assert mm.locator("#toast-host button:has-text('Apply')").count() == 0
+        assert "Some Bystander" in mm.inner_text("#toast-host")
+
+    def test_technique_step_banner_shows_both_moves(self, table):
+        """B4 Q1 UX (DESIGN_technique_difficulty.md §2.7, TD-10): auto-apply is
+        only legible at the table because the roll banner shows both moves —
+        the MM's declared label and the Technique that stepped it."""
+        mm, player = table
+        mm.click("button:has-text('Start Combat')")
+        mm.wait_for_timeout(600)
+        player.wait_for_timeout(400)
+
+        player.evaluate(
+            """() => onStrikeResult({
+                attacker: 'Zahna', target: 'goblin',
+                roll: {dice_rolled: [6, 5], dice_kept: [6, 5], dice_sum: 11,
+                       attribute_modifier: 0, skill_modifier: 0,
+                       difficulty_modifier: 0, total: 11, outcome: 'full_success',
+                       outcome_label: 'Full Success', outcome_description: '',
+                       sparks_spent: 0, difficulty: 'Standard'},
+                endurance_remaining: 5, sparks_remaining: 3, press_used: false,
+                technique_step: {technique_id: 'weapon_mastery', technique_name: 'Weapon Mastery',
+                                  from: 'Hard', to: 'Standard'},
+            })""")
+        player.wait_for_timeout(400)
+
+        banner = player.inner_text("#play-roll-result-box")
+        assert "Hard" in banner and "Standard" in banner and "Weapon Mastery" in banner
+        assert player.locator("#play-roll-result-box .technique-step-banner").count() == 1
+
+    def test_ordinary_strike_banner_has_no_technique_step(self, table):
+        """Same box, no Technique fired — TD-10 must not change the banner
+        when `technique_step` is absent."""
+        mm, player = table
+        mm.click("button:has-text('Start Combat')")
+        mm.wait_for_timeout(600)
+        player.wait_for_timeout(400)
+
+        player.evaluate(
+            """() => onStrikeResult({
+                attacker: 'Zahna', target: 'goblin',
+                roll: {dice_rolled: [6, 5], dice_kept: [6, 5], dice_sum: 11,
+                       attribute_modifier: 0, skill_modifier: 0,
+                       difficulty_modifier: 0, total: 11, outcome: 'full_success',
+                       outcome_label: 'Full Success', outcome_description: '',
+                       sparks_spent: 0, difficulty: 'Standard'},
+                endurance_remaining: 5, sparks_remaining: 3, press_used: false,
+            })""")
+        player.wait_for_timeout(400)
+
+        assert player.locator("#play-roll-result-box .technique-step-banner").count() == 0
 
 # ---------------------------------------------------------------------------
 # Builder — saved content has to be reachable again
@@ -457,6 +625,155 @@ class TestAdvancementAndSparks:
         player.click("button[data-tab='builder']")
         player.wait_for_timeout(500)
         assert "Technique pick" in player.inner_text("#builder-technique-list")
+
+
+# ---------------------------------------------------------------------------
+# TD-20 (DESIGN §8): pickTechniqueChoice's non-domain choices fallback
+# ---------------------------------------------------------------------------
+
+class TestTechniqueChoicePicker:
+    """`pickTechniqueChoice` used to build only domain-name option lists, so
+    Weapon Mastery/Acclimated/Field of Mastery — none of which are domain-
+    granting — offered whatever domain list the character's primary Facet
+    happened to map to as candidate "weapon types". TD-19 gave the three a
+    `choices` list of their own in facet.yaml; TD-20 makes the picker use it.
+
+    `selectTechnique`'s own `def` lookup has an unrelated, pre-existing bug
+    (docs/TODO.md T9: it reads `character_facets[].techniques`, a field that
+    does not exist on the wire) that leaves the Builder tab's "Available"
+    Technique list always empty, so a real click-through was not reachable.
+    These tests call `pickTechniqueChoice` directly with a Technique
+    definition read from the real, correctly-shaped
+    `ruleset.techniques[facet].branches[].tiers[].techniques[]` structure —
+    the same direct-injection approach TD-10's Strike-banner tests already
+    use in this file when the natural trigger path is separately broken or
+    impractical to stage.
+    """
+
+    def _find_technique(self, page, tech_id):
+        return page.evaluate(
+            """id => {
+                for (const facetId in state.ruleset.techniques) {
+                    for (const branch of state.ruleset.techniques[facetId].branches) {
+                        for (const tier of branch.tiers) {
+                            const found = tier.techniques.find(t => t.id === id);
+                            if (found) return found;
+                        }
+                    }
+                }
+                return null;
+            }""",
+            tech_id)
+
+    def test_weapon_mastery_choice_reaches_technique_choices_on_the_character(self, table, live_server):
+        mm, player = table
+
+        # Grant a Technique pick the only way currently reachable: two Body
+        # skill advances cross the 5-rank-advance Facet-level threshold
+        # (facet.yaml advancement.facet_level_threshold). Zahna is created
+        # with no Background (custom/none is the create-character default in
+        # `table`), so both skills start clean at Novice/0 marks — each maxes
+        # to Master (3 rank advances) well within the 100 marks sent, and two
+        # skills' worth (6 advances) crosses the threshold of 5 for 1 SP each,
+        # inside the 4-SP session budget.
+        for skill_id in ("athletics", "stealth"):
+            mm.evaluate(
+                "args => sendWS({type: 'skill_advance', player_name: args.p, "
+                "skill_id: args.s, marks: 100})",
+                {"p": "Zahna", "s": skill_id})
+            mm.wait_for_timeout(400)
+
+        # `technique_picks_available` really is incremented server-side at
+        # this point — `character.advance_skill` computed it correctly — but
+        # the `skill_advanced` broadcast never carries the field and
+        # `app.js`'s handler never applies it to `state.character` (a third,
+        # separate pre-existing wiring gap; see docs/TODO.md T10). A reload
+        # re-authenticates from the stored token and re-fetches full session
+        # state, which — unlike the incremental broadcast — does carry the
+        # true value, so this routes around the gap rather than depending on
+        # a fix that is out of TD-20's scope. A plain reload would re-run the
+        # invite-join flow instead, since the page URL still carries the
+        # invite token query param that takes precedence over sessionStorage
+        # (app.js's DOMContentLoaded routing) — going to the bare origin
+        # avoids that and falls into the stored-token branch.
+        player.goto(live_server)
+        player.wait_for_selector("#game-screen:not(.hidden)", timeout=10000)
+        player.wait_for_timeout(500)
+
+        picks = player.evaluate("() => state.character.technique_picks_available")
+        assert picks >= 1, "skill advance did not grant a Technique pick"
+
+        weapon_mastery = self._find_technique(player, "weapon_mastery")
+        assert weapon_mastery is not None
+        assert weapon_mastery["choices"] == ["blades", "blunt", "polearms", "unarmed"]
+
+        # Kick off the real picker without awaiting it in-page — the Promise
+        # only resolves once the dialog's Confirm button is clicked, below.
+        player.evaluate(
+            "def => { window.__pickResult = undefined; "
+            "pickTechniqueChoice(def).then(r => { window.__pickResult = r; }); }",
+            weapon_mastery)
+        player.wait_for_selector(".modal-input", timeout=5000)
+
+        option_values = player.eval_on_selector_all(".modal-input option", "els => els.map(e => e.value)")
+        assert option_values == ["blades", "blunt", "polearms", "unarmed"], (
+            "picker did not offer Weapon Mastery's own choices — "
+            f"got {option_values}")
+
+        player.select_option(".modal-input", "blades")
+        player.click("button[data-act='ok']")
+        player.wait_for_function("() => window.__pickResult !== undefined", timeout=5000)
+        resolved = player.evaluate("() => window.__pickResult")
+        assert resolved == "blades"
+
+        # `selectTechnique` would send exactly this once its own `def` lookup
+        # (docs/TODO.md T9) is fixed; sending it here proves the resolved
+        # choice — not just the dialog's local state — is what reaches the
+        # character over the real `technique_select` WS handler.
+        player.evaluate(
+            "choice => sendWS({type: 'technique_select', technique_id: 'weapon_mastery', choice})",
+            resolved)
+        player.wait_for_timeout(500)
+
+        # `onTechniqueSelected` (app.js) never applies `msg.choice` to
+        # `state.character.technique_choices` — a fourth pre-existing wiring
+        # gap alongside T9/T10 (docs/TODO.md T11). The character's stored
+        # `technique_choices` is correct server-side regardless (`Character
+        # .select_technique`, `character.py:402`); fetch it the same way as
+        # the picks-available check above rather than trust the incremental
+        # broadcast handler this test is not about.
+        player.goto(live_server)
+        player.wait_for_selector("#game-screen:not(.hidden)", timeout=10000)
+        player.wait_for_timeout(500)
+
+        techniques = player.evaluate("() => state.character.techniques")
+        choices = player.evaluate("() => state.character.technique_choices")
+        assert "weapon_mastery" in techniques
+        assert choices["weapon_mastery"] == "blades"
+
+    def test_domain_granting_technique_keeps_the_domain_list_behaviour(self, table):
+        """A Technique with no `choices` — every domain-granting one; TD-19
+        gave `choices` to exactly the three non-domain Techniques — must
+        still get the pre-existing domain-list picker, not an empty result."""
+        _, player = table
+        arcane_study = self._find_technique(player, "arcane_study")
+        assert arcane_study is not None
+        assert arcane_study.get("choices") is None
+
+        player.evaluate(
+            "def => { window.__pickResult2 = undefined; "
+            "pickTechniqueChoice(def).then(r => { window.__pickResult2 = r; }); }",
+            arcane_study)
+        player.wait_for_selector(".modal-input", timeout=5000)
+
+        option_labels = player.eval_on_selector_all(".modal-input option", "els => els.map(e => e.textContent)")
+        # Domain options render as "Name (type)" (the pre-existing branch) —
+        # never a bare weapon/hardship/field string, which is what a wrongly
+        # taken `choices` fallback would produce instead.
+        assert option_labels, "domain picker offered no options"
+        assert all("(" in label and ")" in label for label in option_labels)
+
+        player.click("button[data-act='cancel']")
 
 
 # ---------------------------------------------------------------------------

--- a/software/tests/test_ascendant_domain.py
+++ b/software/tests/test_ascendant_domain.py
@@ -480,3 +480,82 @@ def test_primary_domain_unaffected_by_ascension(ruleset):
         intent="copy a page", ruleset=ruleset,
     )
     assert result.request.difficulty_label == "Easy"  # focused/minor
+
+
+# ---------------------------------------------------------------------------
+# B4 Q2 pin (docs/DECISIONS.md) — the two domain grant routes price off their
+# own table, not off the primary domain's table. TD-1 (docs/TASKS_technique_
+# difficulty.md): these three tests must pass against the *current* engine
+# with no engine changes — character.py:406-410 and engine.py:330-338 already
+# implement the ruling. If any of these three fail, the engine does not
+# implement B4 Q2; that is an escalation, not a license to patch the engine.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "scope,expected",
+    [("minor", "Hard"), ("significant", "Very Hard"), ("major", "Very Hard")],
+)
+def test_b4q2_ascendant_domain_prices_off_broad_table_no_step(ruleset, scope, expected):
+    """B4 Q2, clause 1: "Ascendant Domain's prismatic territory prices off the
+    Broad table alone" — at all three scopes, with no additional character-side
+    step layered on top. Chronomancy is Broad; the Broad table alone gives
+    Hard/Very Hard/Very Hard for minor/significant/major. A leaked extra step
+    would only be visible at minor, where Broad still has room to climb.
+    """
+    char = _mind_mage(ruleset)
+    assert char.select_technique(
+        "ascendant_domain_mind", ruleset=ruleset, choice="chronomancy"
+    )[0]
+
+    result = resolve_magic_roll(
+        character=char, domain_id="chronomancy", scope=scope,
+        intent="bend a moment", ruleset=ruleset,
+    )
+    assert result.request.difficulty_label == expected
+
+
+def test_b4q2_second_domain_prices_off_own_table_one_step_harder(ruleset):
+    """B4 Q2, clause 2: "A Second Domain grant resolves on its own domain type's
+    table, one step harder." Storm is Standard; Standard/minor is normally
+    "Standard". As a Second Domain it must land one step harder than *that* —
+    "Hard" — not one step harder than the primary domain's own table.
+    """
+    char = _soul_mage(ruleset)  # primary domain: fire (Focused)
+    assert char.select_technique("second_domain", ruleset=ruleset, choice="storm")[0]
+
+    result = resolve_magic_roll(
+        character=char, domain_id="storm", scope="minor",
+        intent="still the wind", ruleset=ruleset,
+    )
+    assert result.request.difficulty_label == "Hard"
+
+
+def test_b4q2_second_domain_focused_primary_does_not_leak_into_pricing(ruleset):
+    """B4 Q2, clause 3 — the case the old wording broke.
+
+    The retired wording read "one difficulty step harder than your primary
+    domain." Inscription (this character's primary) is Focused, whose table is
+    Easy/Standard/Hard for minor/significant/major. Read literally, the old
+    wording would step *that* table: Focused-minor (Easy) + one step =
+    Standard. Illusion — the Second Domain grant — is Standard, whose own
+    table already reads minor=Standard; stepped harder that is Hard.
+
+    So the old wording and the correct ruling disagree on this exact case:
+    old wording -> Standard, B4 Q2 -> Hard. This is why the defect was
+    invisible for a Standard-or-Broad-primary caster (their table and the
+    grant's table often coincide) and only bites a Focused-primary caster.
+    """
+    char = _mind_mage(ruleset)  # primary domain: inscription (Focused)
+    assert char.select_technique(
+        "second_domain_mind", ruleset=ruleset, choice="illusion"
+    )[0]
+
+    result = resolve_magic_roll(
+        character=char, domain_id="illusion", scope="minor",
+        intent="veil a doorway", ruleset=ruleset,
+    )
+    assert result.request.difficulty_label == "Hard"
+    assert result.request.difficulty_label != "Standard", (
+        "this is the exact value the retired 'harder than your primary "
+        "domain' wording would have produced for a Focused-primary caster"
+    )

--- a/software/tests/test_combat.py
+++ b/software/tests/test_combat.py
@@ -2,12 +2,14 @@
 import random
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from app.facets.registry import build_ruleset
+from app.facets.schema import StepTriggerDef, TechniqueDef
 from app.game import combat
 
 
@@ -482,6 +484,72 @@ class TestApplyResolveDamage:
 
 
 # ---------------------------------------------------------------------------
+# apply_final_blow_removal() — B4 Q3, TD-13: *The Final Blow* is a licensed
+# override, resolved as a defeat event through the canonical defeat path,
+# never a raw `resolve_current = 0` write.
+# ---------------------------------------------------------------------------
+
+class TestApplyFinalBlowRemoval:
+    def test_removal_produces_a_defeat_event(self, ruleset):
+        """Works on any target, Bosses included — the removal does not care
+        how much Resolve remained."""
+        result = combat.apply_final_blow_removal(8)
+        assert result.resolve_current == 0
+        assert result.defeated is True
+        assert result.depletion == 8
+
+    def test_removal_routes_through_phase_crossed(self, ruleset):
+        """The drop to 0 must be detected by the same `phase_crossed`
+        primitive `apply_resolve_damage` uses — a Boss phase sitting between
+        the target's current Resolve and 0 must still fire, exactly as it
+        would from an ordinary Strike that happened to zero the pool."""
+        result = combat.apply_final_blow_removal(8, phase_thresholds=[2])
+        assert result.phase_index == 0
+
+        # Already at/under every threshold: no re-fire, same "fires exactly
+        # once" invariant apply_resolve_damage's phase tests pin.
+        already_low = combat.apply_final_blow_removal(1, phase_thresholds=[2])
+        assert already_low.phase_index is None
+
+    def test_transcript_entry_is_distinguishable_from_a_resolve_zero_defeat(self, ruleset):
+        """A Final Blow removal must be tellable apart from an ordinary
+        Strike that happened to deplete Resolve to exactly 0 — both by
+        result *type* (a future sim series can `isinstance`-branch) and by
+        the `cause` field a transcript/broadcast can log directly."""
+        ordinary_defeat = combat.apply_resolve_damage(2, "full_success", ruleset)
+        final_blow = combat.apply_final_blow_removal(2)
+
+        assert ordinary_defeat.resolve_current == 0
+        assert ordinary_defeat.defeated is True
+        assert final_blow.resolve_current == 0
+        assert final_blow.defeated is True
+
+        # Same surface-level outcome; different type and a distinguishing cause.
+        assert not isinstance(ordinary_defeat, combat.FinalBlowResult)
+        assert isinstance(final_blow, combat.FinalBlowResult)
+        assert not hasattr(ordinary_defeat, "cause")
+        assert final_blow.cause == "final_blow"
+
+    def test_no_raw_resolve_current_zero_write_in_source(self):
+        """Guards the P11 invariant at the source level: nowhere in
+        `apply_final_blow_removal` may `resolve_current` be assigned `0`
+        directly outside of building the `FinalBlowResult` via
+        `phase_crossed` — the function must route the crossing check
+        through `phase_crossed`, matching `apply_resolve_damage`'s shape,
+        rather than a bare `resolve_current = 0` that would skip it."""
+        import inspect
+
+        source = inspect.getsource(combat.apply_final_blow_removal)
+        assert "phase_crossed(" in source, (
+            "apply_final_blow_removal must route through phase_crossed"
+        )
+        assert "resolve_current = 0" not in source.replace(" ", ""), (
+            "found a raw `resolve_current = 0` write — must route through "
+            "phase_crossed like apply_resolve_damage does"
+        )
+
+
+# ---------------------------------------------------------------------------
 # enemy_armor_resolve_bonus() — D1 flat Resolve from armor (A8)
 # ---------------------------------------------------------------------------
 
@@ -856,3 +924,257 @@ class TestResolveIncomingCondition:
         result = combat.resolve_incoming_condition(1, "light", 2, ruleset)
         assert result.tier == 0
         assert result.armor_spent is True
+
+
+# ---------------------------------------------------------------------------
+# apply_character_difficulty_step() — TD-5, B4 Q1's composition mechanism
+# (DESIGN_technique_difficulty.md §2.2, §5)
+#
+# Tests inject synthetic TechniqueDef instances via a thin ruleset wrapper so
+# this rule is pinned independently of TD-6's real facet.yaml metadata —
+# TD-5 is sequenced before TD-6 precisely so the mechanism is proven first.
+# ---------------------------------------------------------------------------
+
+class _FakeRulesetWithTechniques:
+    """Wraps a real `MergedRuleset` but overrides `get_technique()` with a
+    caller-supplied map, so composition tests do not depend on which real
+    Techniques (if any) carry `difficulty_step` metadata."""
+
+    def __init__(self, base_ruleset, techniques: dict):
+        self._base = base_ruleset
+        self._techniques = techniques
+
+    def __getattr__(self, name):
+        return getattr(self._base, name)
+
+    def get_technique(self, technique_id):
+        return self._techniques.get(technique_id)
+
+
+def _character(techniques=None, technique_choices=None):
+    return SimpleNamespace(
+        techniques=techniques or [], technique_choices=technique_choices or {},
+    )
+
+
+def _auto_step_technique(tech_id, *, match, against, step="easier"):
+    return TechniqueDef(
+        id=tech_id, name=tech_id, description=".",
+        difficulty_step=step,
+        step_trigger=StepTriggerDef(kind="auto", match=match, against=against),
+    )
+
+
+def _declared_step_technique(tech_id, *, step="easier"):
+    return TechniqueDef(
+        id=tech_id, name=tech_id, description=".",
+        difficulty_step=step,
+        step_trigger=StepTriggerDef(kind="declared"),
+    )
+
+
+class TestApplyCharacterDifficultyStep:
+    def test_clamping_from_easy_stays_easy(self, ruleset):
+        tech = _auto_step_technique("weapon_mastery", match="weapon_category", against="blades")
+        fake = _FakeRulesetWithTechniques(ruleset, {"weapon_mastery": tech})
+        character = _character(techniques=["weapon_mastery"])
+        context = {"weapon_category": "blades"}
+
+        label, applied = combat.apply_character_difficulty_step(
+            "Easy", character, context, fake,
+        )
+        assert label == "Easy"
+        assert applied == "weapon_mastery"
+
+    def test_hard_plus_step_yields_standard_not_easy(self, ruleset):
+        """Proves the step composes with the MM's call rather than
+        replacing it — DESIGN §5.4."""
+        tech = _auto_step_technique("weapon_mastery", match="weapon_category", against="blades")
+        fake = _FakeRulesetWithTechniques(ruleset, {"weapon_mastery": tech})
+        character = _character(techniques=["weapon_mastery"])
+        context = {"weapon_category": "blades"}
+
+        label, applied = combat.apply_character_difficulty_step(
+            "Hard", character, context, fake,
+        )
+        assert label == "Standard"
+        assert applied == "weapon_mastery"
+
+    def test_two_qualifying_techniques_yield_one_step_deterministic_id(self, ruleset):
+        """The guardrail: at most one character-side step per roll. Two
+        auto Techniques both qualify; only one step is applied, and the
+        reported id is the lower of the two regardless of unlock order."""
+        tech_a = _auto_step_technique("acclimated", match="hazard_type", against="cold")
+        tech_b = _auto_step_technique("weapon_mastery", match="weapon_category", against="blades")
+        fake = _FakeRulesetWithTechniques(ruleset, {"acclimated": tech_a, "weapon_mastery": tech_b})
+        character = _character(techniques=["weapon_mastery", "acclimated"])
+        context = {"hazard_type": "cold", "weapon_category": "blades"}
+
+        label, applied = combat.apply_character_difficulty_step(
+            "Hard", character, context, fake,
+        )
+        assert label == "Standard"  # only one step, not two
+        assert applied == "acclimated"  # lowest technique id wins between two autos
+
+    def test_unlocked_only_technique_not_in_characters_list_does_not_fire(self, ruleset):
+        tech = _auto_step_technique("weapon_mastery", match="weapon_category", against="blades")
+        fake = _FakeRulesetWithTechniques(ruleset, {"weapon_mastery": tech})
+        character = _character(techniques=[])  # not unlocked
+        context = {"weapon_category": "blades"}
+
+        label, applied = combat.apply_character_difficulty_step(
+            "Hard", character, context, fake,
+        )
+        assert label == "Hard"
+        assert applied is None
+
+    def test_absent_context_field_does_not_fire(self, ruleset):
+        tech = _auto_step_technique("weapon_mastery", match="weapon_category", against="blades")
+        fake = _FakeRulesetWithTechniques(ruleset, {"weapon_mastery": tech})
+        character = _character(techniques=["weapon_mastery"])
+        context = {}  # weapon_category absent entirely
+
+        label, applied = combat.apply_character_difficulty_step(
+            "Standard", character, context, fake,
+        )
+        assert label == "Standard"
+        assert applied is None
+
+    def test_mismatched_choice_does_not_fire(self, ruleset):
+        """`against == "choice"` compares the roll context against the
+        character's recorded `technique_choices` for that Technique —
+        Weapon Mastery (blades) does not fire on an unarmed Strike."""
+        tech = _auto_step_technique("weapon_mastery", match="weapon_category", against="choice")
+        fake = _FakeRulesetWithTechniques(ruleset, {"weapon_mastery": tech})
+        character = _character(
+            techniques=["weapon_mastery"],
+            technique_choices={"weapon_mastery": "blades"},
+        )
+        context = {"weapon_category": "unarmed"}
+
+        label, applied = combat.apply_character_difficulty_step(
+            "Standard", character, context, fake,
+        )
+        assert label == "Standard"
+        assert applied is None
+
+    def test_matched_choice_fires(self, ruleset):
+        tech = _auto_step_technique("weapon_mastery", match="weapon_category", against="choice")
+        fake = _FakeRulesetWithTechniques(ruleset, {"weapon_mastery": tech})
+        character = _character(
+            techniques=["weapon_mastery"],
+            technique_choices={"weapon_mastery": "blades"},
+        )
+        context = {"weapon_category": "blades"}
+
+        label, applied = combat.apply_character_difficulty_step(
+            "Standard", character, context, fake,
+        )
+        assert label == "Easy"
+        assert applied == "weapon_mastery"
+
+    def test_declared_beats_auto(self, ruleset):
+        """A player-declared toggle wins precedence over a qualifying auto
+        Technique, even when the auto Technique's id sorts lower."""
+        declared = _declared_step_technique("zzz_the_uncanny_angle")
+        auto = _auto_step_technique("aaa_weapon_mastery", match="weapon_category", against="blades")
+        fake = _FakeRulesetWithTechniques(
+            ruleset, {"zzz_the_uncanny_angle": declared, "aaa_weapon_mastery": auto},
+        )
+        character = _character(techniques=["aaa_weapon_mastery", "zzz_the_uncanny_angle"])
+        context = {
+            "weapon_category": "blades",
+            "declared_technique_ids": ["zzz_the_uncanny_angle"],
+        }
+
+        label, applied = combat.apply_character_difficulty_step(
+            "Hard", character, context, fake,
+        )
+        assert label == "Standard"
+        assert applied == "zzz_the_uncanny_angle"
+
+    def test_declared_technique_not_toggled_does_not_fire(self, ruleset):
+        tech = _declared_step_technique("the_uncanny_angle")
+        fake = _FakeRulesetWithTechniques(ruleset, {"the_uncanny_angle": tech})
+        character = _character(techniques=["the_uncanny_angle"])
+        context = {}  # not declared this roll
+
+        label, applied = combat.apply_character_difficulty_step(
+            "Standard", character, context, fake,
+        )
+        assert label == "Standard"
+        assert applied is None
+
+    def test_no_qualifying_technique_leaves_label_unchanged(self, ruleset):
+        character = _character(techniques=[])
+        label, applied = combat.apply_character_difficulty_step(
+            "Standard", character, {}, ruleset,
+        )
+        assert label == "Standard"
+        assert applied is None
+
+    def test_technique_without_step_metadata_never_fires(self, ruleset):
+        """A Technique the character has unlocked but which carries no
+        `difficulty_step`/`step_trigger` (the overwhelming majority) is
+        silently skipped rather than raising."""
+        plain = TechniqueDef(id="forcing_hand", name="Forcing Hand", description=".")
+        fake = _FakeRulesetWithTechniques(ruleset, {"forcing_hand": plain})
+        character = _character(techniques=["forcing_hand"])
+
+        label, applied = combat.apply_character_difficulty_step(
+            "Standard", character, {"weapon_category": "blades"}, fake,
+        )
+        assert label == "Standard"
+        assert applied is None
+
+
+class TestReviewFindingsB4:
+    """Regressions for two rule bypasses found in review of the B4 cycle.
+
+    Both slipped past the original suite because no test exercised a character
+    with zero Sparks, and none asserted that a skill-scoped Technique *fails* to
+    fire on the wrong skill.
+    """
+
+    def test_skill_scoped_technique_does_not_fire_on_another_skill(self, ruleset):
+        """Acclimated is "Endurance rolls against your chosen hardship" (II.4a).
+
+        Before the fix the trigger matched on `hazard_type` alone, so a character
+        with Acclimated (extreme cold) rolling Combat in a warm tavern — while
+        sending `hazard_type: "extreme cold"` — got the step. The engine was
+        implementing a wider rule than the book prints.
+        """
+        character = SimpleNamespace(
+            techniques=["acclimated"],
+            technique_choices={"acclimated": "extreme cold"},
+        )
+        wrong_skill = {"skill_id": "combat", "hazard_type": "extreme cold"}
+        label, applied = combat.apply_character_difficulty_step(
+            "Hard", character, wrong_skill, ruleset)
+        assert (label, applied) == ("Hard", None)
+
+        right_skill = {"skill_id": "endurance", "hazard_type": "extreme cold"}
+        label, applied = combat.apply_character_difficulty_step(
+            "Hard", character, right_skill, ruleset)
+        assert (label, applied) == ("Standard", "acclimated")
+
+    def test_field_of_mastery_is_scoped_to_lore(self, ruleset):
+        character = SimpleNamespace(
+            techniques=["field_of_mastery"],
+            technique_choices={"field_of_mastery": "history"},
+        )
+        assert combat.apply_character_difficulty_step(
+            "Hard", character, {"skill_id": "persuade", "knowledge_field": "history"},
+            ruleset) == ("Hard", None)
+        assert combat.apply_character_difficulty_step(
+            "Hard", character, {"skill_id": "lore", "knowledge_field": "history"},
+            ruleset) == ("Standard", "field_of_mastery")
+
+    def test_non_iterable_declared_ids_does_not_raise(self, ruleset):
+        """A client sending a scalar used to raise straight through the dispatch
+        loop and disconnect the sender."""
+        character = SimpleNamespace(techniques=["the_uncanny_angle"], technique_choices={})
+        for junk in (5, None, {"a": 1}, "the_uncanny_angle"):
+            label, applied = combat.apply_character_difficulty_step(
+                "Hard", character, {"declared_technique_ids": junk}, ruleset)
+            assert label == "Hard" and applied is None

--- a/software/tests/test_facets_schema.py
+++ b/software/tests/test_facets_schema.py
@@ -37,6 +37,7 @@ from app.facets.schema import (
     SparkEarnMethod,
     SparkMechanicDef,
     SparkVariantsDef,
+    StepTriggerDef,
     StrikeDepletionDef,
     TechniqueDef,
     ThreatClockDef,
@@ -184,6 +185,61 @@ class TestTechniqueDef:
         t = TechniqueDef(id="tier2", name="Tier 2", description=".",
                          prerequisites=["tier1a", "tier1b"])
         assert len(t.prerequisites) == 2
+
+    # -- TD-4: difficulty_step / step_trigger (B4 Q1) --------------------
+
+    def test_no_step_parses_unchanged(self):
+        """Every pre-existing Technique omits these fields and must parse
+        exactly as before — both optional fields default to None."""
+        t = TechniqueDef(id="forcing_hand", name="Forcing Hand", description="...")
+        assert t.difficulty_step is None
+        assert t.step_trigger is None
+
+    def test_auto_trigger_technique_parses(self):
+        t = TechniqueDef(
+            id="weapon_mastery", name="Weapon Mastery", description=".",
+            difficulty_step="easier",
+            step_trigger=StepTriggerDef(kind="auto", match="weapon_type", against="choice"),
+        )
+        assert t.difficulty_step == "easier"
+        assert t.step_trigger.kind == "auto"
+        assert t.step_trigger.match == "weapon_type"
+        assert t.step_trigger.against == "choice"
+
+    def test_declared_trigger_technique_parses(self):
+        t = TechniqueDef(
+            id="the_uncanny_angle", name="The Uncanny Angle", description=".",
+            difficulty_step="easier",
+            step_trigger=StepTriggerDef(kind="declared"),
+        )
+        assert t.step_trigger.kind == "declared"
+        assert t.step_trigger.match is None
+        assert t.step_trigger.against is None
+
+    def test_invalid_step_trigger_kind_raises(self):
+        with pytest.raises(ValidationError):
+            StepTriggerDef(kind="bogus")
+
+    def test_invalid_difficulty_step_raises(self):
+        with pytest.raises(ValidationError):
+            TechniqueDef(id="x", name="X", description=".", difficulty_step="sideways")
+
+    # -- TD-19: choices (DESIGN §8) ----------------------------------------
+
+    def test_no_choices_parses_unchanged(self):
+        """Every Technique that predates TD-19 — including domain-granting
+        ones, which build their picker from the domain catalog instead —
+        omits `choices` and must parse exactly as before."""
+        t = TechniqueDef(id="forcing_hand", name="Forcing Hand", description="...")
+        assert t.choices is None
+
+    def test_technique_with_choices_parses(self):
+        t = TechniqueDef(
+            id="weapon_mastery", name="Weapon Mastery", description=".",
+            has_choice=True, choice_prompt="Choose a weapon type.",
+            choices=["blades", "blunt", "polearms", "unarmed"],
+        )
+        assert t.choices == ["blades", "blunt", "polearms", "unarmed"]
 
 
 # ---------------------------------------------------------------------------
@@ -595,6 +651,98 @@ class TestGroupRollDef:
 # deliberately permissive on which attribute a Strike uses.
 # ---------------------------------------------------------------------------
 
+class TestDifficultyStepMetadataInBaseFacet:
+    """TD-6 (B4 Q1): exactly five Techniques in facet.yaml carry
+    `difficulty_step` metadata. Pinned by name so a sixth cannot be added
+    without a deliberate change to this test — `pressure_point` is
+    deliberately deferred (DESIGN §2.5, docs/TODO.md T7) and must stay out."""
+
+    EXPECTED = {
+        "weapon_mastery": ("easier", "auto"),
+        "acclimated": ("easier", "auto"),
+        "field_of_mastery": ("easier", "auto"),
+        "steady_hand": ("easier", "auto"),
+        "the_uncanny_angle": ("easier", "declared"),
+    }
+
+    def _techniques_with_step(self, ruleset):
+        found = {}
+        for facet_id, tree in ruleset.techniques.items():
+            for branch in tree.branches:
+                for tier_def in branch.tiers:
+                    for tech in tier_def.techniques:
+                        if tech.difficulty_step is not None:
+                            found[tech.id] = tech
+        return found
+
+    def test_exactly_five_techniques_carry_the_step(self, ruleset):
+        found = self._techniques_with_step(ruleset)
+        assert set(found) == set(self.EXPECTED), (
+            f"expected exactly {sorted(self.EXPECTED)}, found {sorted(found)}"
+        )
+
+    def test_each_technique_matches_its_expected_step_and_trigger_kind(self, ruleset):
+        found = self._techniques_with_step(ruleset)
+        for tech_id, (expected_step, expected_kind) in self.EXPECTED.items():
+            tech = found[tech_id]
+            assert tech.difficulty_step == expected_step, tech_id
+            assert tech.step_trigger is not None, tech_id
+            assert tech.step_trigger.kind == expected_kind, tech_id
+
+    def test_pressure_point_deliberately_carries_no_step(self, ruleset):
+        pressure_point = ruleset.get_technique("pressure_point")
+        assert pressure_point is not None
+        assert pressure_point.difficulty_step is None
+        assert pressure_point.step_trigger is None
+
+    def test_auto_triggers_match_declared_fields(self, ruleset):
+        found = self._techniques_with_step(ruleset)
+        assert found["weapon_mastery"].step_trigger.match == "weapon_type"
+        assert found["weapon_mastery"].step_trigger.against == "choice"
+        assert found["acclimated"].step_trigger.match == "hazard_type"
+        assert found["acclimated"].step_trigger.against == "choice"
+        assert found["field_of_mastery"].step_trigger.match == "knowledge_field"
+        assert found["field_of_mastery"].step_trigger.against == "choice"
+        assert found["steady_hand"].step_trigger.match == "skill_id"
+        assert found["steady_hand"].step_trigger.against == "finesse"
+
+
+class TestFinalBlowOverrideFlag:
+    """TD-12 (B4 Q3): exactly one Technique in facet.yaml carries
+    `removes_target_from_conflict`, and it is *The Final Blow*. Pinned by
+    name, same pattern as `TestDifficultyStepMetadataInBaseFacet`, so a
+    second override can't creep in without a deliberate test change —
+    overrides must stay greppable and countable."""
+
+    def _techniques_with_override_flag(self, ruleset):
+        found = {}
+        for facet_id, tree in ruleset.techniques.items():
+            for branch in tree.branches:
+                for tier_def in branch.tiers:
+                    for tech in tier_def.techniques:
+                        if tech.removes_target_from_conflict:
+                            found[tech.id] = tech
+        return found
+
+    def test_exactly_one_technique_carries_the_flag(self, ruleset):
+        found = self._techniques_with_override_flag(ruleset)
+        assert set(found) == {"the_final_blow"}, (
+            f"expected only 'the_final_blow', found {sorted(found)}"
+        )
+
+    def test_the_final_blow_carries_the_flag(self, ruleset):
+        tech = ruleset.get_technique("the_final_blow")
+        assert tech is not None
+        assert tech.removes_target_from_conflict is True
+
+    def test_an_ordinary_technique_does_not_carry_the_flag(self, ruleset):
+        """Backward compatibility: a Technique that predates TD-12 parses
+        with the flag defaulting to False."""
+        unstoppable = ruleset.get_technique("unstoppable")
+        assert unstoppable is not None
+        assert unstoppable.removes_target_from_conflict is False
+
+
 class TestWeaponCategories:
     def test_base_ruleset_loads_equipment_block(self, ruleset):
         assert isinstance(ruleset.equipment, EquipmentDef)
@@ -607,3 +755,66 @@ class TestWeaponCategories:
         assert categories["light"].attributes == ["dexterity"]
         assert categories["ranged"].attributes == ["dexterity"]
         assert categories["unarmed"].attributes == ["strength", "dexterity"]
+
+    def test_weapon_types_present_and_orthogonal_to_categories(self, ruleset):
+        """TD-18 (DESIGN §8): `weapon_types` is the separate, fictional
+        vocabulary Weapon Mastery masters — it is not a subset or a rename
+        of `weapon_categories` above. Only `unarmed` legitimately overlaps
+        both lists; the rest are disjoint by design."""
+        types = set(ruleset.equipment.weapon_types)
+        assert types == {"blades", "blunt", "polearms", "unarmed"}
+        categories = set(ruleset.equipment.weapon_categories)
+        assert types - categories == {"blades", "blunt", "polearms"}
+
+
+class TestNonDomainTechniqueChoices:
+    """TD-19 (DESIGN §8): the three non-domain `has_choice` Techniques
+    (Weapon Mastery, Acclimated, Field of Mastery) enumerate their options
+    as data. `choice_prompt` stays the printed prose; `choices` is what the
+    picker renders from — and the two must never drift apart, since the
+    book and the data would then be silently telling players different
+    things a Technique can be taken in."""
+
+    NON_DOMAIN_CHOICE_TECHNIQUES = ("weapon_mastery", "acclimated", "field_of_mastery")
+
+    def test_all_three_carry_choices(self, ruleset):
+        for tech_id in self.NON_DOMAIN_CHOICE_TECHNIQUES:
+            tech = ruleset.get_technique(tech_id)
+            assert tech is not None, tech_id
+            assert tech.choices, f"{tech_id} has no choices"
+
+    def test_a_technique_without_choices_still_parses(self, ruleset):
+        """Backward compatibility: an ordinary Technique with no `choices`
+        (most of the tree) is unaffected."""
+        forcing_hand = ruleset.get_technique("forcing_hand")
+        assert forcing_hand is not None
+        assert forcing_hand.choices is None
+
+    def test_choices_match_the_printed_choice_prompt_text(self, ruleset):
+        """The acceptance test that matters: every value in `choices` must
+        appear (case-insensitively) in `choice_prompt`, so the machine-
+        readable list and the book's human-readable prompt cannot drift."""
+        mismatches = []
+        for tech_id in self.NON_DOMAIN_CHOICE_TECHNIQUES:
+            tech = ruleset.get_technique(tech_id)
+            prompt = tech.choice_prompt.lower()
+            for choice in tech.choices:
+                if choice.lower() not in prompt:
+                    mismatches.append(f"{tech_id}: '{choice}' not found in "
+                                      f"choice_prompt {tech.choice_prompt!r}")
+        assert not mismatches, "\n".join(mismatches)
+
+    def test_weapon_mastery_choices_are_the_fictional_weapon_type_vocabulary(self, ruleset):
+        tech = ruleset.get_technique("weapon_mastery")
+        assert tech.choices == ["blades", "blunt", "polearms", "unarmed"]
+
+    def test_acclimated_choices(self, ruleset):
+        tech = ruleset.get_technique("acclimated")
+        assert tech.choices == ["extreme cold", "extreme heat", "altitude", "deprivation"]
+
+    def test_field_of_mastery_choices_are_suggestions_not_a_closed_set(self, ruleset):
+        """PHB II.4a: 'or another domain with MM approval' — nothing in the
+        schema or the engine enforces membership in this list (INV-8)."""
+        tech = ruleset.get_technique("field_of_mastery")
+        assert "history" in tech.choices
+        assert "arcane theory" in tech.choices

--- a/software/tests/test_websocket.py
+++ b/software/tests/test_websocket.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import yaml
@@ -343,6 +343,109 @@ class TestWebSocketRoll:
             assert msg["type"] == "roll_result"
             # Sparks spent must not exceed what the character had
             assert msg["roll"]["sparks_spent"] <= 3
+
+    # -----------------------------------------------------------------------
+    # TD-8: hazard_type / knowledge_field on the generic roll (B4 Q1)
+    # -----------------------------------------------------------------------
+
+    def test_roll_without_hazard_or_knowledge_field_behaves_as_today(self, client, session_with_character):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({"type": "roll", "attribute_id": "intelligence", "difficulty": "Standard"})
+            msg = ws.receive_json()
+            assert msg["type"] == "roll_result"
+            assert msg["technique_step"] is None
+            assert msg["roll"]["difficulty"] == "Standard"
+
+    def test_roll_hazard_type_and_knowledge_field_round_trip_without_error(self, client, session_with_character):
+        """Neither field qualifies any Technique this character holds — the
+        point here is only that the server accepts and does not choke on them."""
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({
+                "type": "roll", "attribute_id": "intelligence", "difficulty": "Standard",
+                "hazard_type": "extreme cold", "knowledge_field": "arcane theory",
+            })
+            msg = ws.receive_json()
+            assert msg["type"] == "roll_result"
+            assert msg["technique_step"] is None
+
+    # -----------------------------------------------------------------------
+    # TD-9: the generic roll handler calls apply_character_difficulty_step
+    # -----------------------------------------------------------------------
+
+    def test_roll_acclimated_steps_difficulty_when_hazard_matches(self, client, session_with_character):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("acclimated")
+        char.technique_choices["acclimated"] = "extreme cold"
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({
+                "type": "roll", "attribute_id": "constitution", "skill_id": "endurance",
+                "difficulty": "Hard", "hazard_type": "extreme cold",
+            })
+            msg = ws.receive_json()
+            assert msg["roll"]["difficulty"] == "Standard"
+            assert msg["technique_step"]["technique_id"] == "acclimated"
+            assert msg["technique_step"]["technique_name"] == "Acclimated"
+
+    def test_roll_field_of_mastery_does_not_fire_on_mismatched_field(self, client, session_with_character):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("field_of_mastery")
+        char.technique_choices["field_of_mastery"] = "history"
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({
+                "type": "roll", "attribute_id": "knowledge", "skill_id": "lore",
+                "difficulty": "Hard", "knowledge_field": "arcane theory",
+            })
+            msg = ws.receive_json()
+            assert msg["roll"]["difficulty"] == "Hard"
+            assert msg["technique_step"] is None
+
+
+# ---------------------------------------------------------------------------
+# TD-9: the magic handler is deliberately NOT wired to difficulty composition
+# (DESIGN_technique_difficulty.md §2.6 — magic difficulty comes from the
+# domain/scope table, and no Technique in this cycle steps it).
+# ---------------------------------------------------------------------------
+
+class TestCastHandlerUnaffectedByDifficultyStep:
+    def test_cast_ignores_a_technique_that_would_fire_on_a_strike(self, client, session_with_character):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.magic_domain = "inscription"
+        char.magic_technique_active = True
+        # A Technique that would step a Strike's difficulty if this context
+        # ever reached apply_character_difficulty_step.
+        char.techniques.append("weapon_mastery")
+        char.technique_choices["weapon_mastery"] = "blades"
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({
+                "type": "cast", "domain_id": "inscription", "scope": "minor",
+                "intent": "test", "weapon_type": "blades",
+            })
+            msg = ws.receive_json()
+            assert msg["type"] == "cast_result"
+            assert "technique_step" not in msg
 
 
 # ---------------------------------------------------------------------------
@@ -922,6 +1025,248 @@ class TestCombatGameplayLoop:
             # The offense modifier should be in the roll
             assert msg["roll"].get("offense_modifier", 0) == 1
 
+    # -----------------------------------------------------------------------
+    # TD-7: weapon_category on the Strike (B4 Q1 — DESIGN §2.4)
+    # -----------------------------------------------------------------------
+
+    def test_strike_without_weapon_category_behaves_as_today(self, client, mm_token, session_with_character):
+        """Backward compatibility: a Strike that never mentions weapon_category
+        or weapon_type is byte-for-byte what it was before TD-7/TD-18."""
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({"type": "strike", "target": "goblin"})
+            msg = ws.receive_json()
+            assert msg["type"] == "strike_result"
+            assert msg["weapon_category"] is None
+            assert msg["weapon_type"] is None
+            assert msg["technique_step"] is None
+            assert msg["roll"]["difficulty"] == "Standard"
+
+    def test_strike_with_valid_weapon_category_round_trips(self, client, mm_token, session_with_character):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({"type": "strike", "target": "goblin", "weapon_category": "light"})
+            msg = ws.receive_json()
+            assert msg["type"] == "strike_result"
+            assert msg["weapon_category"] == "light"
+
+    def test_strike_with_unknown_weapon_category_returns_error(self, client, mm_token, session_with_character):
+        """INV-8 is about attribute/skill pairings, not the reference-data
+        vocabulary — an unrecognised category is a mistake, not a house rule,
+        and is rejected with a message rather than silently dropped."""
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({"type": "strike", "target": "goblin", "weapon_category": "explosive"})
+            msg = ws.receive_json()
+            assert msg["type"] == "error"
+            assert "explosive" in msg["message"]
+
+    # -----------------------------------------------------------------------
+    # TD-18: weapon_type — the orthogonal, fictional vocabulary (DESIGN §8)
+    # -----------------------------------------------------------------------
+
+    def test_strike_with_valid_weapon_type_round_trips(self, client, mm_token, session_with_character):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({"type": "strike", "target": "goblin", "weapon_type": "blades"})
+            msg = ws.receive_json()
+            assert msg["type"] == "strike_result"
+            assert msg["weapon_type"] == "blades"
+
+    def test_strike_with_unknown_weapon_type_returns_error(self, client, mm_token, session_with_character):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({"type": "strike", "target": "goblin", "weapon_type": "explosive"})
+            msg = ws.receive_json()
+            assert msg["type"] == "error"
+            assert "explosive" in msg["message"]
+
+    # -----------------------------------------------------------------------
+    # TD-9: the Strike handler calls apply_character_difficulty_step
+    # -----------------------------------------------------------------------
+    #
+    # TD-18 (DESIGN §8): weapon_mastery's step_trigger now matches
+    # `weapon_type` (blades/blunt/polearms/unarmed — the fictional
+    # vocabulary Weapon Mastery masters), not `weapon_category` (the
+    # mechanical IV.1 vocabulary that only defaults the attribute). The two
+    # are orthogonal and both ship on the Strike message. The four tests
+    # below replace the TD-7-era pair that fired Weapon Mastery through
+    # `weapon_category` — that only ever worked because the test used
+    # `"light"` as a stand-in value for both fields, which is exactly the
+    # bug the TD-7 escalation found (see docs/LOG_technique_difficulty.md).
+
+    def test_strike_weapon_mastery_fires_on_matching_weapon_type(self, client, mm_token, session_with_character):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("weapon_mastery")
+        char.technique_choices["weapon_mastery"] = "blades"
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({
+                "type": "strike", "target": "goblin",
+                "weapon_type": "blades", "difficulty": "Hard",
+            })
+            msg = ws.receive_json()
+            assert msg["type"] == "strike_result"
+            assert msg["roll"]["difficulty"] == "Standard"
+            assert msg["technique_step"] == {
+                "technique_id": "weapon_mastery",
+                "technique_name": "Weapon Mastery",
+                "from": "Hard",
+                "to": "Standard",
+            }
+
+    def test_strike_weapon_mastery_does_not_fire_on_mismatched_weapon_type(self, client, mm_token, session_with_character):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("weapon_mastery")
+        char.technique_choices["weapon_mastery"] = "blades"
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({
+                "type": "strike", "target": "goblin",
+                "weapon_type": "blunt", "difficulty": "Hard",
+            })
+            msg = ws.receive_json()
+            assert msg["type"] == "strike_result"
+            assert msg["roll"]["difficulty"] == "Hard"
+            assert msg["technique_step"] is None
+
+    def test_strike_weapon_mastery_does_not_fire_when_weapon_type_absent(self, client, mm_token, session_with_character):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("weapon_mastery")
+        char.technique_choices["weapon_mastery"] = "blades"
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({"type": "strike", "target": "goblin", "difficulty": "Hard"})
+            msg = ws.receive_json()
+            assert msg["type"] == "strike_result"
+            assert msg["weapon_type"] is None
+            assert msg["roll"]["difficulty"] == "Hard"
+            assert msg["technique_step"] is None
+
+    def test_strike_weapon_category_alone_does_not_fire_weapon_mastery(self, client, mm_token, session_with_character):
+        """Proves the two vocabularies are separate axes (DESIGN §8): a
+        Strike that only carries `weapon_category` — never `weapon_type` —
+        must not fire Weapon Mastery, even when the category value happens
+        to equal the character's recorded choice."""
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("weapon_mastery")
+        char.technique_choices["weapon_mastery"] = "blades"
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({
+                "type": "strike", "target": "goblin",
+                "weapon_category": "light", "difficulty": "Hard",
+            })
+            msg = ws.receive_json()
+            assert msg["type"] == "strike_result"
+            assert msg["weapon_category"] == "light"
+            assert msg["roll"]["difficulty"] == "Hard"
+            assert msg["technique_step"] is None
+
+    def test_iii_3_513_mordai_weapon_mastery_blades_standard_becomes_easy(
+        self, client, mm_token, session_with_character,
+    ):
+        """Regression for the flagship case the TD-7 escalation found broken
+        (docs/LOG_technique_difficulty.md, docs/DESIGN_technique_difficulty.md
+        §8): III.3:513 — Mordai, Weapon Mastery (blades), striking with a
+        blade at the MM's declared Standard, gets Easy end to end."""
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("weapon_mastery")
+        char.technique_choices["weapon_mastery"] = "blades"
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({
+                "type": "strike", "target": "goblin",
+                "weapon_category": "standard", "weapon_type": "blades",
+                "difficulty": "Standard",
+            })
+            msg = ws.receive_json()
+            assert msg["type"] == "strike_result"
+            assert msg["roll"]["difficulty"] == "Easy"
+            assert msg["technique_step"]["technique_id"] == "weapon_mastery"
+            assert msg["technique_step"]["from"] == "Standard"
+            assert msg["technique_step"]["to"] == "Easy"
+
     def test_armor_downgrades_condition(self, client, mm_token, session_with_character):
         """0.3: Light armor downgrades Tier 2 condition to Tier 1."""
         session, _ = session_with_character
@@ -1378,6 +1723,77 @@ class TestCombatGameplayLoop:
             ws.send_json({"type": "react", "reaction": "dodge"})
             third = ws.receive_json()
             assert third["endurance_cost"] == 2
+
+    # -----------------------------------------------------------------------
+    # TD-9: the reaction handler calls apply_character_difficulty_step
+    # -----------------------------------------------------------------------
+
+    def test_react_declared_technique_steps_difficulty(self, client, mm_token, session_with_character):
+        """A fiction-scoped Technique (The Uncanny Angle) only fires when the
+        player toggles it via declared_technique_ids — it composes with the
+        Parry roll's difficulty exactly like an auto Technique would."""
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("the_uncanny_angle")
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({
+                "type": "react", "reaction": "parry", "difficulty": "Hard",
+                "declared_technique_ids": ["the_uncanny_angle"],
+            })
+            msg = ws.receive_json()
+            assert msg["roll"]["difficulty"] == "Standard"
+            assert msg["technique_step"] == {
+                "technique_id": "the_uncanny_angle",
+                "technique_name": "The Uncanny Angle",
+                "from": "Hard",
+                "to": "Standard",
+            }
+
+    def test_react_technique_not_toggled_does_not_fire(self, client, mm_token, session_with_character):
+        """Same Technique, same character, but not declared on this roll —
+        a fiction-scoped step never applies itself."""
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("the_uncanny_angle")
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({"type": "react", "reaction": "parry", "difficulty": "Hard"})
+            msg = ws.receive_json()
+            assert msg["roll"]["difficulty"] == "Hard"
+            assert msg["technique_step"] is None
+
+    def test_react_absorb_carries_no_technique_step_key(self, client, mm_token, session_with_character):
+        """Absorb never rolls, so there is no difficulty to step — the key is
+        present and None rather than silently absent, matching every other
+        reaction payload shape."""
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({"type": "react", "reaction": "absorb"})
+            msg = ws.receive_json()
+            assert msg["technique_step"] is None
 
     def test_skill_advance_checks_skill_points(self, client, mm_token, session_with_character):
         """0.7: Skill advance deducts session_skill_points_remaining."""
@@ -3145,6 +3561,269 @@ class TestEnemyStrikeDepletion:
             _auth_player(ws, player_token)
             ws.send_json({"type": "enemy_strike", "tracker_key": "x",
                           "outcome": "full_success"})
+            msg = ws.receive_json()
+
+        assert msg["type"] == "error"
+        assert "Unknown event type" in msg["message"]
+
+
+class TestFinalBlowLicensedOverride:
+    """TD-14 (B4 Q3): *The Final Blow* fires on 7+ (both success tiers per
+    the BRIEF), never on a 6- failure, is refused a second time in the same
+    session, and does not commit an enemy removal without a separate MM
+    confirmation (`final_blow_confirm`) — auto-apply governs difficulty
+    steps, not actor removal (DESIGN §4).
+
+    Dice are pinned with `patch("random.randint", ...)`: Zahna's Strength
+    is 3 (+1 minor modifier, `valid_attributes` fixture) and the Strike
+    uses the default Standard difficulty (+0), so a constant die value of
+    6 lands well past the 10+ full-success threshold, 3 lands in the 7-9
+    partial band, and 1 lands at failure — regardless of the extra
+    Spark die (all dice equal, so dropping the lowest changes nothing).
+    """
+
+    def _session_with_enemy(self, client, mm_headers, resolve=8):
+        session_id = client.post(
+            "/api/sessions/", json={"name": "Final Blow"}, headers=mm_headers,
+        ).json()["session_id"]
+        client.post("/api/enemies/", json={
+            "session_id": session_id, "id": "boss", "name": "Boss",
+            "tier": "boss", "resolve": resolve,
+        }, headers=mm_headers)
+        return session_id
+
+    def _spawn(self, ws, enemy_id="boss"):
+        ws.send_json({"type": "spawn_enemy", "enemy_id": enemy_id})
+        msg = ws.receive_json()
+        assert msg["type"] == "enemy_spawned"
+        return msg["tracker_key"]
+
+    def _start_combat(self, ws):
+        ws.send_json({"type": "combat_start"})
+        return ws.receive_json()
+
+    def test_fires_on_full_success(self, client, mm_token, session_with_character):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("the_final_blow")
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            with patch("random.randint", return_value=6):
+                ws.send_json({
+                    "type": "strike", "target": "boss",
+                    "final_blow": True, "sparks_spent": 1,
+                })
+                msg = ws.receive_json()
+
+        assert msg["type"] == "strike_result"
+        assert msg["roll"]["outcome"] == "full_success"
+        assert msg["final_blow_available"] is True
+
+    def test_fires_on_partial_success(self, client, mm_token, session_with_character):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("the_final_blow")
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            with patch("random.randint", return_value=3):
+                ws.send_json({
+                    "type": "strike", "target": "boss",
+                    "final_blow": True, "sparks_spent": 1,
+                })
+                msg = ws.receive_json()
+
+        assert msg["roll"]["outcome"] == "partial_success"
+        assert msg["final_blow_available"] is True
+
+    def test_does_not_fire_on_failure(self, client, mm_token, session_with_character):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("the_final_blow")
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            with patch("random.randint", return_value=1):
+                ws.send_json({
+                    "type": "strike", "target": "boss",
+                    "final_blow": True, "sparks_spent": 1,
+                })
+                msg = ws.receive_json()
+
+        assert msg["roll"]["outcome"] == "failure"
+        assert msg["final_blow_available"] is False
+
+    def test_second_use_in_same_session_is_refused(self, client, mm_token, session_with_character):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("the_final_blow")
+        char.techniques_used_this_session.append("the_final_blow")
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({
+                "type": "strike", "target": "boss",
+                "final_blow": True, "sparks_spent": 1,
+            })
+            msg = ws.receive_json()
+
+        assert msg["type"] == "error"
+        assert "already" in msg["message"].lower()
+
+    def test_removal_does_not_commit_without_mm_confirmation(
+        self, client, mm_headers, mm_token, session_with_character,
+    ):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("the_final_blow")
+
+        client.post("/api/enemies/", json={
+            "session_id": session_id, "id": "boss", "name": "Boss",
+            "tier": "boss", "resolve": 8,
+        }, headers=mm_headers)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            key = self._spawn(ws)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            with patch("random.randint", return_value=6):
+                ws.send_json({
+                    "type": "strike", "target": "boss",
+                    "final_blow": True, "sparks_spent": 1,
+                })
+                msg = ws.receive_json()
+
+        assert msg["final_blow_available"] is True
+
+        enemy = session_store.get(session_id).active_enemies[key]
+        assert enemy.resolve_current != 0
+        assert "the_final_blow" not in char.techniques_used_this_session
+
+    def test_mm_confirm_commits_the_removal(
+        self, client, mm_headers, mm_token, session_with_character,
+    ):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("the_final_blow")
+
+        client.post("/api/enemies/", json={
+            "session_id": session_id, "id": "boss", "name": "Boss",
+            "tier": "boss", "resolve": 8,
+        }, headers=mm_headers)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            key = self._spawn(ws)
+            self._start_combat(ws)
+            ws.send_json({
+                "type": "final_blow_confirm", "player": "Zahna", "tracker_key": key,
+            })
+            msg = ws.receive_json()
+
+        assert msg["type"] == "enemy_updated"
+        assert msg["resolve_current"] == 0
+        assert msg["defeated"] is True
+        assert msg["cause"] == "final_blow"
+        assert "the_final_blow" in char.techniques_used_this_session
+
+    def test_second_mm_confirm_is_refused(
+        self, client, mm_headers, mm_token, session_with_character,
+    ):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("the_final_blow")
+
+        client.post("/api/enemies/", json={
+            "session_id": session_id, "id": "boss", "name": "Boss",
+            "tier": "boss", "resolve": 8,
+        }, headers=mm_headers)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            key = self._spawn(ws)
+            self._start_combat(ws)
+            ws.send_json({
+                "type": "final_blow_confirm", "player": "Zahna", "tracker_key": key,
+            })
+            ws.receive_json()  # enemy_updated
+            ws.send_json({
+                "type": "final_blow_confirm", "player": "Zahna", "tracker_key": key,
+            })
+            msg = ws.receive_json()
+
+        assert msg["type"] == "error"
+
+    def test_zero_sparks_cannot_use_the_final_blow(self, client, mm_token, session_with_character):
+        """Review finding: the precondition tested the Spark the client *asked*
+        to spend, but `_spend_sparks` clamps to what the character holds and
+        silently spends 0 — so a character at 0 Sparks got the capstone free.
+        The printed cost is "when you spend a Spark on a Combat roll" (II.4a)."""
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+        char = session_store.get(session_id).characters["Zahna"]
+        char.techniques.append("the_final_blow")
+        char.sparks = 0
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_mm(ws, mm_token, session_id)
+            self._start_combat(ws)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            with patch("random.randint", return_value=6):
+                ws.send_json({
+                    "type": "strike", "target": "boss",
+                    "final_blow": True, "sparks_spent": 1,
+                })
+                msg = ws.receive_json()
+
+        assert msg["type"] == "error"
+        assert "Spark" in msg["message"]
+        assert "the_final_blow" not in char.techniques_used_this_session
+
+    def test_non_mm_cannot_confirm_final_blow(self, client, mm_token, session_with_character):
+        session, _ = session_with_character
+        session_id = session["session_id"]
+        player_token = create_session_token("Zahna", session_id)
+
+        with client.websocket_connect("/ws") as ws:
+            _auth_player(ws, player_token)
+            ws.send_json({
+                "type": "final_blow_confirm", "player": "Zahna", "tracker_key": "x",
+            })
             msg = ws.receive_json()
 
         assert msg["type"] == "error"


### PR DESCRIPTION
Implements the Brain ruling in `docs/DECISIONS.md` **B4**, escalated after the style audit's `Normal:`-field pass found three baselines that did not exist. Brief, design, tasks, and execution log are in `docs/*_technique_difficulty.md`.

### Q1 — Technique steps compose with the MM's call
MM's label first, character's step second, four-rung ladder clamps. **Guardrail: character-side steps never stack with each other** — at most one per roll, whatever the source, mirroring two guardrails already in canon.

The decisive evidence: III.3's play example had **already ruled this in print** — *"Standard difficulty, but Weapon Mastery makes this one step easier, so Easy"* — and never stated it as a rule. This ratifies existing text rather than choosing against it.

The rule lives in `combat.py` and nowhere else, because the simulator may only *drive* that module, never carry its own copy.

Mechanically-scoped steps auto-apply per the UX ruling, and the banner shows both moves: `Hard (MM) → Standard (Weapon Mastery)`. A step nobody sees is a step nobody trusts.

### Q2 — the penalty rides the grant route
Ascendant Domain's prismatic territory prices off the Broad table alone; the Broad table already *is* the price of breadth. Ratifies working code — and fixes a **latent defect**: "harder than your primary domain", read literally, deletes the penalty entirely for a Focused-primary caster, because Focused-plus-one *is* the standard table. Five surfaces re-anchored.

### Q3 — The Final Blow is a licensed override
Not a rider, so III.3's "riders never defeat" sentence is **byte-identical** and stays true. Succeeds on 7+; a partial's cost shapes the aftermath, never the removal. Resolved as a **defeat event through the canonical path**, never a raw `resolve_current` write, so phase logic and transcripts stay coherent (P11 invariant). MM confirmation required — auto-apply governs difficulty steps, not deleting an actor from someone's encounter.

### Found during implementation
A Worker escalated rather than guessing, and caught a **planning error**: two weapon vocabularies are orthogonal and both ship. `weapon_category` (heavy/standard/light/ranged/unarmed) sets a Strike's attribute; `weapon_type` (blades/blunt/polearms/unarmed) is what *Weapon Mastery* masters. A longsword is *standard* **and** *blades*. Conflating them meant the exact case the ruling cites could never fire.

### Corpus
Intact. `standard_party()` carries no Techniques, so Series 7 and 9 stand as published — one advisory sentence in MM1, no re-run.

**72 new tests; suite at 1371.**

**Stacked PR 4 of 5.** Base is `feat/books-apparatus-and-bestiary` (#20) — review the single commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)